### PR TITLE
ip_as_username should serve as an example

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -88,8 +88,8 @@ conf.webirc_pass = {
 
 // Some IRCDs require the clients IP via the username/ident
 conf.ip_as_username = [
-	//"irc.network.com",
-	//"127.0.0.1"
+    //"irc.network.com",
+    //"127.0.0.1"
 ];
 
 // Whether to verify IRC servers' SSL certificates against built-in well-known certificate authorities


### PR DESCRIPTION
I doubt irc.network.com actually needs its username as an IP. But for localhost, there might be an actual IRC server with unknown configuration running there.
