### PR TITLE
Show feedback when saving settings

### DIFF
--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -205,6 +205,11 @@ html, body { height:100%; }
 #kiwi .settings table td {
     padding:0.5em 1em;
 }
+#kiwi .settings .save .feedback {
+    display: none;
+    position: relative;
+    left: -1.6em;
+}
 
 
 

--- a/client/assets/dev/applet_settings.js
+++ b/client/assets/dev/applet_settings.js
@@ -48,7 +48,8 @@
 
 
         saveSettings: function () {
-            var settings = _kiwi.global.settings;
+            var settings = _kiwi.global.settings,
+                feedback;
 
             // Stop settings being updated while we're saving one by one
             _kiwi.global.settings.off('change', this.loadSettings, this);
@@ -60,6 +61,11 @@
             settings.set('show_timestamps', $('.setting-show_timestamps', this.$el).is(':checked'));
 
             settings.save();
+
+            feedback = $('.feedback', this.$el);
+            feedback.fadeIn('slow', function () {
+                feedback.fadeOut('slow');
+            })
 
             // Continue listening for setting changes
             _kiwi.global.settings.on('change', this.loadSettings, this);

--- a/client/assets/dev/index.html.tmpl
+++ b/client/assets/dev/index.html.tmpl
@@ -189,7 +189,7 @@
                 </tr>
 
                 <tr class="save">
-                    <td colspan="2"><button class="save">Save</button>​​​​​​​​​</td>
+                    <td colspan="2"><button class="save">Save</button><br/><span class="feedback">Saved!</span></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Fades `Saved!` in and out when the save settings button is clicked.

Resolves feature request #179.
