### PR TITLE
support rfc2812-style LIST

### DIFF
--- a/server/irc/server.js
+++ b/server/irc/server.js
@@ -68,10 +68,10 @@ function onListStart(event) {
 };
 
 function onListChannel(event) {
-    if (!this.busy_listing) {
-      onListStart.call(this, event);
-    }
     var buf;
+    if (!this.busy_listing) {
+      onListStart.call(this);
+    }
     this.list_buffer.push({
         channel: event.channel,
         num_users: event.num_users,


### PR DESCRIPTION
In rfc2812 and servers like ngircd, no 321 response is given before the channel list.
