### PR TITLE
Use a space instead of colon as event delimiter

### DIFF
--- a/server/irc/channel.js
+++ b/server/irc/channel.js
@@ -27,7 +27,7 @@ var IrcChannel = function(irc_connection, name) {
         topicsetby:     onTopicSetBy,
         mode:           onMode
     };
-    EventBinder.bindIrcEvents('channel:' + this.name, this.irc_events, this, irc_connection);
+    EventBinder.bindIrcEvents('channel ' + this.name, this.irc_events, this, irc_connection);
 }
 
 
@@ -35,7 +35,7 @@ module.exports = IrcChannel;
 
 
 IrcChannel.prototype.dispose = function (){
-    EventBinder.unbindIrcEvents('channel:' + this.name, this.irc_events, this.irc_connection);
+    EventBinder.unbindIrcEvents('channel ' + this.name, this.irc_events, this.irc_connection);
     this.irc_connection = undefined;
 };
 
@@ -210,29 +210,3 @@ function onMode(event) {
         modes: event.modes
     });
 };
-
-
-/*
-server:event
-server:*
-channel:#channel:event
-channel:*:event
-user:event
-user:*
-
-Server disconnected:
-    server:disconnect
-    server:*
-
-Joining channel #kiwiirc:
-    channel:#kiwiirc:join
-    channel:*:join
-
-Channel message:
-    channel:#kiwiirc:privmsg
-    channel:*:privmsg
-
-Private message:
-    user:privmsg
-    user:*
-*/

--- a/server/irc/commands.js
+++ b/server/irc/commands.js
@@ -96,7 +96,7 @@ var listeners = {
         var nick =  command.params[0];
         this.irc_connection.registered = true;
         this.cap_negotation = false;
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':connect', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' connect', {
             nick: nick
         });
     },
@@ -125,19 +125,19 @@ var listeners = {
                 }
             }
         }
-        this.irc_connection.emit('server:'  + this.irc_connection.irc_host.hostname + ':options', {
+        this.irc_connection.emit('server '  + this.irc_connection.irc_host.hostname + ' options', {
             options: this.irc_connection.options,
             cap: this.irc_connection.cap.enabled
         });
     },
     'RPL_ENDOFWHOIS': function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':endofwhois', {
+        this.irc_connection.emit('user ' + command.params[1] + ' endofwhois', {
             nick: command.params[1],
             msg: command.trailing
         });
     },
     'RPL_WHOISUSER': function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':whoisuser', {
+        this.irc_connection.emit('user ' + command.params[1] + ' whoisuser', {
             nick: command.params[1],
             ident: command.params[2],
             host: command.params[3],
@@ -145,65 +145,65 @@ var listeners = {
         });
     },
     'RPL_WHOISSERVER': function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':whoisserver', {
+        this.irc_connection.emit('user ' + command.params[1] + ' whoisserver', {
             nick: command.params[1],
             irc_server: command.params[2]
         });
     },
     'RPL_WHOISOPERATOR': function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':whoisoperator', {
+        this.irc_connection.emit('user ' + command.params[1] + ' whoisoperator', {
             nick: command.params[1],
             msg: command.trailing
         });
     },
     'RPL_WHOISCHANNELS':       function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':whoischannels', {
+        this.irc_connection.emit('user ' + command.params[1] + ' whoischannels', {
             nick: command.params[1],
             chans: command.trailing
         });
     },
     'RPL_WHOISMODES': function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':whoismodes', {
+        this.irc_connection.emit('user ' + command.params[1] + ' whoismodes', {
             nick: command.params[1],
             msg: command.trailing
         });
     },
     'RPL_WHOISIDLE': function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':whoisidle', {
+        this.irc_connection.emit('user ' + command.params[1] + ' whoisidle', {
             nick: command.params[1],
             idle: command.params[2],
             logon: command.params[3] || undefined
         });
     },
     'RPL_WHOISREGNICK': function (command) {
-        this.irc_connection.emit('user:' + command.params[1] + ':whoisregnick', {
+        this.irc_connection.emit('user ' + command.params[1] + ' whoisregnick', {
             nick: command.params[1],
             msg: command.trailing
         });
     },
     'RPL_LISTSTART': function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':list_start', {});
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' list_start', {});
     },
     'RPL_LISTEND': function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':list_end', {});
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' list_end', {});
     },
     'RPL_LIST': function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':list_channel', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' list_channel', {
             channel: command.params[1],
             num_users: parseInt(command.params[2], 10),
             topic: command.trailing
         });
     },
     'RPL_MOTD': function (command) {
-        this.irc_connection.emit('server:'  + this.irc_connection.irc_host.hostname + ':motd', {
+        this.irc_connection.emit('server '  + this.irc_connection.irc_host.hostname + ' motd', {
             motd: command.trailing + '\n'
         });
     },
     'RPL_MOTDSTART': function (command) {
-        this.irc_connection.emit('server:'  + this.irc_connection.irc_host.hostname + ':motd_start', {});
+        this.irc_connection.emit('server '  + this.irc_connection.irc_host.hostname + ' motd_start', {});
     },
     'RPL_ENDOFMOTD': function (command) {
-        this.irc_connection.emit('server:'  + this.irc_connection.irc_host.hostname + ':motd_end', {});
+        this.irc_connection.emit('server '  + this.irc_connection.irc_host.hostname + ' motd_end', {});
     },
     'RPL_NAMEREPLY': function (command) {
         var members = command.trailing.split(' ');
@@ -228,7 +228,7 @@ var listeners = {
             member_list.push({nick: member, modes: modes});
         });
 
-        this.irc_connection.emit('channel:' + command.params[2] + ':userlist', {
+        this.irc_connection.emit('channel ' + command.params[2] + ' userlist', {
             users: member_list,
             channel: command.params[2]
         });
@@ -236,14 +236,14 @@ var listeners = {
 
     
     'RPL_ENDOFNAMES': function (command) {
-        this.irc_connection.emit('channel:' + command.params[1] + ':userlist_end', {
+        this.irc_connection.emit('channel ' + command.params[1] + ' userlist_end', {
             channel: command.params[1]
         });
     },
 
 
     'RPL_BANLIST': function (command) {
-        this.irc_connection.emit('channel:' + command.params[1] + ':banlist', {
+        this.irc_connection.emit('channel ' + command.params[1] + ' banlist', {
             channel: command.params[1],
             banned: command.params[2],
             banned_by: command.params[3],
@@ -251,24 +251,24 @@ var listeners = {
         });
     },
     'RPL_ENDOFBANLIST': function (command) {
-        this.irc_connection.emit('channel:' + command.params[1] + ':banlist_end', {
+        this.irc_connection.emit('channel ' + command.params[1] + ' banlist_end', {
             channel: command.params[1]
         });
     },
     'RPL_TOPIC': function (command) {
-        this.irc_connection.emit('channel:' + command.params[1] + ':topic', {
+        this.irc_connection.emit('channel ' + command.params[1] + ' topic', {
             channel: command.params[1],
             topic: command.trailing
         });
     },
     'RPL_NOTOPIC': function (command) {
-        this.irc_connection.emit('channel:' + command.params[1] + ':topic', {
+        this.irc_connection.emit('channel ' + command.params[1] + ' topic', {
             channel: command.params[1],
             topic: ''
         });
     },
     'RPL_TOPICWHOTIME': function (command) {
-        this.irc_connection.emit('channel:' + command.params[1] + ':topicsetby', {
+        this.irc_connection.emit('channel ' + command.params[1] + ' topicsetby', {
             nick: command.params[2],
             channel: command.params[1],
             when: command.params[3]
@@ -287,7 +287,7 @@ var listeners = {
             channel = command.params[0];
         }
         
-        this.irc_connection.emit('channel:' + channel + ':join', {
+        this.irc_connection.emit('channel ' + channel + ' join', {
             nick: command.nick,
             ident: command.ident,
             hostname: command.hostname,
@@ -297,7 +297,7 @@ var listeners = {
 
 
     'PART': function (command) {
-        this.irc_connection.emit('channel:' + command.params[0] + ':part', {
+        this.irc_connection.emit('channel ' + command.params[0] + ' part', {
             nick: command.nick,
             ident: command.ident,
             hostname: command.hostname,
@@ -308,7 +308,7 @@ var listeners = {
 
 
     'KICK': function (command) {
-        this.irc_connection.emit('channel:' + command.params[0] + ':kick', {
+        this.irc_connection.emit('channel ' + command.params[0] + ' kick', {
             kicked: command.params[1],
             nick: command.nick,
             ident: command.ident,
@@ -320,7 +320,7 @@ var listeners = {
 
 
     'QUIT': function (command) {
-        this.irc_connection.emit('user:' + command.nick + ':quit', {
+        this.irc_connection.emit('user ' + command.nick + ' quit', {
             nick: command.nick,
             ident: command.ident,
             hostname: command.hostname,
@@ -335,7 +335,7 @@ var listeners = {
         if ((command.trailing.charAt(0) === String.fromCharCode(1)) && (command.trailing.charAt(command.trailing.length - 1) === String.fromCharCode(1))) {
             // It's a CTCP response
             namespace = (command.params[0] == this.irc_connection.nick) ? 'user' : 'channel';
-            this.irc_connection.emit(namespace + ':' + command.params[0] + ':ctcp_response', {
+            this.irc_connection.emit(namespace + ' ' + command.params[0] + ' ctcp_response', {
                 nick: command.nick,
                 ident: command.ident,
                 hostname: command.hostname,
@@ -344,7 +344,7 @@ var listeners = {
             });
         } else {
             namespace = (command.params[0] == this.irc_connection.nick) ? 'user' : 'channel';
-            this.irc_connection.emit(namespace + ':' + command.params[0] + ':notice', {
+            this.irc_connection.emit(namespace + ' ' + command.params[0] + ' notice', {
                 nick: command.nick,
                 ident: command.ident,
                 hostname: command.hostname,
@@ -354,7 +354,7 @@ var listeners = {
         }
     },
     'NICK': function (command) {
-        this.irc_connection.emit('user:' + command.nick + ':nick', {
+        this.irc_connection.emit('user ' + command.nick + ' nick', {
             nick: command.nick,
             ident: command.ident,
             hostname: command.hostname,
@@ -368,13 +368,13 @@ var listeners = {
         var channel = command.params[0],
             topic = command.trailing || '';
 
-        this.irc_connection.emit('channel:' + channel + ':topic', {
+        this.irc_connection.emit('channel ' + channel + ' topic', {
             nick: command.nick,
             channel: channel,
             topic: topic
         });
     },
-    'MODE': function (command) {                
+    'MODE': function (command) {
         var chanmodes = this.irc_connection.options.CHANMODES || [],
             prefixes = this.irc_connection.options.PREFIX || [],
             always_param = (chanmodes[0] || '').concat((chanmodes[1] || '')),
@@ -423,7 +423,7 @@ var listeners = {
             }
         }
         
-        event = (_.contains(this.irc_connection.options.CHANTYPES, command.params[0][0]) ? 'channel:' : 'user:') + command.params[0] + ':mode';
+        event = (_.contains(this.irc_connection.options.CHANTYPES, command.params[0][0]) ? 'channel ' : 'user ') + command.params[0] + ' mode';
         
         this.irc_connection.emit(event, {
             target: command.params[0],
@@ -449,7 +449,7 @@ var listeners = {
                 this.irc_connection.write('NOTICE ' + command.nick + ' :' + String.fromCharCode(1) + 'CLIENTINFO SOURCE VERSION TIME' + String.fromCharCode(1));
             } else {
                 namespace = (command.params[0].toLowerCase() == this.irc_connection.nick.toLowerCase()) ? 'user' : 'channel';
-                this.irc_connection.emit(namespace + ':' + command.nick + ':ctcp_request', {
+                this.irc_connection.emit(namespace + ' ' + command.nick + ' ctcp_request', {
                     nick: command.nick,
                     ident: command.ident,
                     hostname: command.hostname,
@@ -460,8 +460,8 @@ var listeners = {
             }
         } else {
             // A message to a user (private message) or to a channel?
-            namespace = (command.params[0] === this.irc_connection.nick) ? 'user:' + command.nick : 'channel:' + command.params[0];
-            this.irc_connection.emit(namespace + ':privmsg', {
+            namespace = (command.params[0] === this.irc_connection.nick) ? 'user ' + command.nick : 'channel ' + command.params[0];
+            this.irc_connection.emit(namespace + ' privmsg', {
                 nick: command.nick,
                 ident: command.ident,
                 hostname: command.hostname,
@@ -540,7 +540,7 @@ var listeners = {
         }
     },
     'AWAY': function (command) {
-        this.irc_connection.emit('user:' + command.nick + ':away', {
+        this.irc_connection.emit('user ' + command.nick + ' away', {
             nick: command.nick,
             msg: command.trailing
         });
@@ -567,82 +567,82 @@ var listeners = {
         // noop
     },
     'ERROR': function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':error', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' error', {
             reason: command.trailing
         });
     },
     ERR_PASSWDMISMATCH: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':password_mismatch', {});
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' password_mismatch', {});
     },
     ERR_LINKCHANNEL: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':channel_redirect', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' channel_redirect', {
             from: command.params[1],
             to: command.params[2]
         });
     },
     ERR_NOSUCHNICK: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':no_such_nick', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' no_such_nick', {
             nick: command.params[1],
             reason: command.trailing
         });
     },
     ERR_CANNOTSENDTOCHAN: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':cannot_send_to_chan', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' cannot_send_to_chan', {
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_TOOMANYCHANNELS: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':too_many_channels', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' too_many_channels', {
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_USERNOTINCHANNEL: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':user_not_in_channel', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' user_not_in_channel', {
             nick: command.params[0],
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_NOTONCHANNEL: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':not_on_channel', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' not_on_channel', {
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_CHANNELISFULL: function (command) {
-            this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':channel_is_full', {
+            this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' channel_is_full', {
                 channel: command.params[1],
                 reason: command.trailing
             });
         },
     ERR_INVITEONLYCHAN: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':invite_only_channel', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' invite_only_channel', {
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_BANNEDFROMCHAN: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':banned_from_channel', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' banned_from_channel', {
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_BADCHANNELKEY: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':bad_channel_key', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' bad_channel_key', {
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_CHANOPRIVSNEEDED: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':chanop_privs_needed', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' chanop_privs_needed', {
             channel: command.params[1],
             reason: command.trailing
         });
     },
     ERR_NICKNAMEINUSE: function (command) {
-        this.irc_connection.emit('server:' + this.irc_connection.irc_host.hostname + ':nickname_in_use', {
+        this.irc_connection.emit('server ' + this.irc_connection.irc_host.hostname + ' nickname_in_use', {
             nick: command.params[1],
             reason: command.trailing
         });

--- a/server/irc/connection.js
+++ b/server/irc/connection.js
@@ -25,7 +25,7 @@ var IrcConnection = function (hostname, port, ssl, nick, user, pass, state) {
 
     EventEmitter2.call(this,{
         wildcard: true,
-        delimiter: ':'
+        delimiter: ' '
     });
     this.setMaxListeners(0);
     
@@ -87,7 +87,7 @@ var IrcConnection = function (hostname, port, ssl, nick, user, pass, state) {
     this.applyIrcEvents();
 
     // Call any modules before making the connection
-    global.modules.emit('irc:connecting', {connection: this})
+    global.modules.emit('irc connecting', {connection: this})
         .done(function () {
             that.connect();
         });
@@ -101,15 +101,15 @@ module.exports.IrcConnection = IrcConnection;
 IrcConnection.prototype.applyIrcEvents = function () {
     // Listen for events on the IRC connection
     this.irc_events = {
-        'server:*:connect':  onServerConnect,
-        'channel:*:join':    onChannelJoin,
+        'server * connect':  onServerConnect,
+        'channel * join':    onChannelJoin,
 
         // TODO: uncomment when using an IrcUser per nick
         //'user:*:privmsg':    onUserPrivmsg,
-        'user:*:nick':       onUserNick,
-        'channel:*:part':    onUserParts,
-        'channel:*:quit':    onUserParts,
-        'channel:*:kick':    onUserKick
+        'user * nick':       onUserNick,
+        'channel * part':    onUserParts,
+        'channel * quit':    onUserParts,
+        'channel * kick':    onUserKick
     };
 
     EventBinder.bindIrcEvents('', this.irc_events, this, this);
@@ -347,7 +347,7 @@ var socketConnectHandler = function () {
     // Let the webirc/etc detection modify any required parameters
     connect_data = findWebIrc.call(this, connect_data);
 
-    global.modules.emit('irc:authorize', connect_data).done(function () {
+    global.modules.emit('irc authorize', connect_data).done(function () {
         // Send any initial data for webirc/etc
         if (connect_data.prepend_data) {
             _.each(connect_data.prepend_data, function(data) {

--- a/server/irc/eventbinder.js
+++ b/server/irc/eventbinder.js
@@ -3,7 +3,7 @@ var _ = require('lodash');
 
 module.exports.bindIrcEvents = function (events_scope, event_map, context, irc_connection) {
     var namespace_prefix = events_scope ?
-        events_scope + ':' :
+        events_scope + ' ' :
         '';
 
     // Make sure we have a holder for the bound events
@@ -26,7 +26,7 @@ module.exports.bindIrcEvents = function (events_scope, event_map, context, irc_c
 
 module.exports.unbindIrcEvents = function (events_scope, event_map, irc_connection) {
     var namespace_prefix = events_scope ?
-        events_scope + ':' :
+        events_scope + ' ' :
         '';
 
     // No bound events? Then we have nothing to do

--- a/server/irc/server.js
+++ b/server/irc/server.js
@@ -32,7 +32,7 @@ var IrcServer = function (irc_connection) {
         chanop_privs_needed:    onChanopPrivsNeeded,
         nickname_in_use:        onNicknameInUse
     };
-    EventBinder.bindIrcEvents('server:*', this.irc_events, this, this.irc_connection);
+    EventBinder.bindIrcEvents('server *', this.irc_events, this, this.irc_connection);
     
 
 };
@@ -42,7 +42,7 @@ module.exports = IrcServer;
 
 
 IrcServer.prototype.dispose = function (){
-    EventBinder.unbindIrcEvents('server:*', this.irc_events, this.irc_connection);
+    EventBinder.unbindIrcEvents('server *', this.irc_events, this.irc_connection);
     this.irc_connection = undefined;
 };
 

--- a/server/irc/user.js
+++ b/server/irc/user.js
@@ -22,7 +22,7 @@ var IrcUser = function (irc_connection, nick) {
         ctcp_request:   onCtcpRequest,
         mode:           onMode
     };
-    EventBinder.bindIrcEvents('user:' + this.nick, this.irc_events, this, irc_connection);
+    EventBinder.bindIrcEvents('user ' + this.nick, this.irc_events, this, irc_connection);
 };
 
 
@@ -30,7 +30,7 @@ module.exports = IrcUser;
 
 
 IrcUser.prototype.dispose = function () {
-    EventBinder.unbindIrcEvents('user:' + this.nick, this.irc_events, this.irc_connection);
+    EventBinder.unbindIrcEvents('user ' + this.nick, this.irc_events, this.irc_connection);
     this.irc_connection = undefined;
 };
 
@@ -44,9 +44,9 @@ function onNick(event) {
     });
 
     // TODO: uncomment when using an IrcUser per nick
-    //EventBinder.unbindIrcEvents('user:' + this.nick, this.irc_events, irc_connection);
+    //EventBinder.unbindIrcEvents('user ' + this.nick, this.irc_events, irc_connection);
     //this.nick = event.newnick;
-    //EventBinder.bindIrcEvents('user:' + this.nick, this.irc_events, this, irc_connection);
+    //EventBinder.bindIrcEvents('user ' + this.nick, this.irc_events, this, irc_connection);
 };
 
 function onAway(event) {

--- a/server_modules/example.js
+++ b/server_modules/example.js
@@ -3,12 +3,12 @@ var kiwiModules = require('../server/modules');
 var module = new kiwiModules.Module('Example Module');
 
 
-module.on('client:connected', function(event, data) {
+module.on('client connected', function(event, data) {
     console.log('Client connection:', data);
 });
 
 
-module.on('client:commands:msg', function(event, data) {
+module.on('client commands msg', function(event, data) {
     console.log('Client msg:', data.args.target, ': ', data.args.msg);
     data.args.msg += ' - modified!';
 });


### PR DESCRIPTION
Fixes issue where channel names containing a colon would break event handling in Kiwi
