### PR TITLE
[ISSUE 293] Mini theme was not showing the channels tree

### DIFF
--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -776,6 +776,18 @@ html, body { height:100%; }
 
 
 
+#kiwi.theme_mini.chanlist_treeview .panels { left:160px; }
+#kiwi.theme_mini.chanlist_treeview .toolbar { position:static; }
+#kiwi.theme_mini.chanlist_treeview .toolbar .app_tools { float:none; }
+#kiwi.theme_mini.chanlist_treeview .toolbar > div { }
+#kiwi.theme_mini.chanlist_treeview .toolbar .tabs { position:absolute; left:0px; bottom:0px; top:0px; margin:0; width:160px; background:#1B1B1B; overflow-y:auto; }
+#kiwi.theme_mini.chanlist_treeview .tabs ul li { display:block; float:none; }
+#kiwi.theme_mini.chanlist_treeview .tabs ul li .activity { float:right; }
+#kiwi.theme_mini.chanlist_treeview .tabs ul li.active { padding-left:1em; }
+
+
+
+
 #kiwi.theme_mini .memberlists {
     background-color: #DADADA;
     border-left: 1px solid #8A8A8A;


### PR DESCRIPTION
Fixed [one bug](https://github.com/prawnsalad/KiwiIRC/issues/293) from the "Mini" theme where it would not show the channel list as a vertical list. 

The final result:
![Final result](http://img856.imageshack.us/img856/545/screenshot20130611at218.png)

This bug is present in the current stable version (and in the oficial server at https://kiwiirc.com/client ...)
