### PR TITLE
Convert whitespaces to fix links sticking together

### DIFF
--- a/client/assets/src/views/controlbox.js
+++ b/client/assets/src/views/controlbox.js
@@ -226,8 +226,8 @@ _kiwi.view.ControlBox = Backbone.View.extend({
         
         // The default command
         if (command_raw[0] !== '/' || command_raw.substr(0, 2) === '//') {
-            // Remove any slash escaping at the start (ie. //), convert whitespaces to regular
-            command_raw = command_raw.replace(/^\/\//, '/').replace(/\s/, ' ');
+            // Remove any slash escaping at the start (ie. //)
+            command_raw = command_raw.replace(/^\/\//, '/');
 
             // Prepend the default command
             command_raw = '/msg ' + _kiwi.app.panels().active.get('name') + ' ' + command_raw;
@@ -240,7 +240,7 @@ _kiwi.view.ControlBox = Backbone.View.extend({
         command_raw = this.preprocessor.process(command_raw);
 
         // Extract the command and parameters
-        params = command_raw.split(' ');
+        params = command_raw.split(/\s/);
         if (params[0][0] === '/') {
             command = params[0].substr(1).toLowerCase();
             params = params.splice(1, params.length - 1);

--- a/client/assets/src/views/panel.js
+++ b/client/assets/src/views/panel.js
@@ -82,7 +82,7 @@ _kiwi.view.Panel = Backbone.View.extend({
             extra_html = _kiwi.view.MediaMessage.buildHtml(url);
 
             // Make the link clickable
-            return '<a class="link_ext" target="_blank" rel="nofollow" href="' + url + '">' + nice + '</a> ' + extra_html;
+            return '<a class="link_ext" target="_blank" rel="nofollow" href="' + url + '">' + nice + '</a>' + extra_html;
         });
 
 


### PR DESCRIPTION
Pasting two different links results in them sticking together because of a &nbsp:
![Links stuck together](http://i.imgur.com/AHuD7rt.png)

Replacing all types of whitespaces with regular ones fixes that.
