### PR TITLE
Small ZNC tweaks

### DIFF
--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -180,6 +180,9 @@ html, body { height:100%; }
 #kiwi .server_select .basic .show_more { }
 #kiwi .server_select .basic tr.pass { display:none; }
 #kiwi .server_select .basic tr.key { display:none; }
+#kiwi .server_select .basic tr.network { display:none; }
+#kiwi .server_select.bouncer_mode .basic tr.network { display:table-row; }
+#kiwi .server_select.bouncer_mode .basic tr.have_pass { display: none; }
 #kiwi .server_select.single_server .basic { border:none; }
 #kiwi .server_select .status {  }
 

--- a/client/assets/src/build.js
+++ b/client/assets/src/build.js
@@ -111,21 +111,21 @@ var index_src = fs.readFileSync(__dirname + '/index.html.tmpl', FILE_ENCODING);
 var vars = {
     base_path: config.get().http_base_path || '/kiwi',
     cache_buster: Math.ceil(Math.random() * 9000).toString(),
-    server_settings: {},
+    server_settings: {
+        bouncer_mode: !!config.get().bouncer_mode
+    },
     client_plugins: []
 };
 
 // Any restricted server mode set?
 if (config.get().restrict_server) {
-    vars.server_settings = {
-        connection: {
-            server: config.get().restrict_server,
-            port: config.get().restrict_server_port || 6667,
-            ssl: config.get().restrict_server_ssl,
-            channel: config.get().restrict_server_channel,
-            nick: config.get().restrict_server_nick,
-            allow_change: false
-        }
+    vars.server_settings.connection = {
+        server: config.get().restrict_server,
+        port: config.get().restrict_server_port || 6667,
+        ssl: config.get().restrict_server_ssl,
+        channel: config.get().restrict_server_channel,
+        nick: config.get().restrict_server_nick,
+        allow_change: false
     };
 }
 

--- a/client/assets/src/index.html.tmpl
+++ b/client/assets/src/index.html.tmpl
@@ -113,6 +113,11 @@
                                 <td><label for="server_select_password">Password</label></td>
                                 <td><input type="password" class="password" id="server_select_password"></td>
                             </tr>
+                            
+                            <tr class="network">
+                                <td><label for="server_select_network">Network</label></td>
+                                <td><input type="network" class="network" id="server_select_network"></td>
+                            </tr>
 
                             <tr class="channel">
                                 <td><label for="server_select_channel">Channel</label></td>

--- a/client/assets/src/views/serverselect.js
+++ b/client/assets/src/views/serverselect.js
@@ -23,6 +23,14 @@ _kiwi.view.ServerSelect = function () {
                     this.$el.addClass('single_server');
                 }
             }
+            
+            if (_kiwi.app.server_settings.bouncer_mode) {
+                // Assume that bouncers always have a password
+                this.$el.find('tr.have_pass input').prop('checked', true);
+                this.$el.find('tr.pass').show();
+                
+                this.$el.addClass('bouncer_mode');
+            }
 
             _kiwi.gateway.bind('onconnect', this.networkConnected, this);
             _kiwi.gateway.bind('connecting', this.networkConnecting, this);
@@ -66,10 +74,16 @@ _kiwi.view.ServerSelect = function () {
                 server: $('input.server', this.$el).val(),
                 port: $('input.port', this.$el).val(),
                 ssl: $('input.ssl', this.$el).prop('checked'),
-                password: $('input.password', this.$el).val(),
                 channel: $('input.channel', this.$el).val(),
                 channel_key: $('input.channel_key', this.$el).val()
             };
+
+            if (_kiwi.app.server_settings.bouncer_mode) {
+                // IRC bouncers like ZNC use a password in the form "username/network:password"
+                values.password = values.nick + '/' + $('input.network', this.$el).val() + ':' + $('input.password', this.$el).val();
+            } else {
+                values.password = $('input.password', this.$el).val();
+            }
 
             this.trigger('server_connect', values);
         },

--- a/config.example.js
+++ b/config.example.js
@@ -191,7 +191,8 @@ conf.client = {
 //conf.restrict_server_nick = "kiwi_";
 
 
-
+// If set, use ZNC bouncer mode.
+conf.bouncer_mode = false;
 
 /*
  * Do not ammend the below lines unless you understand the changes!


### PR DESCRIPTION
As per #320, here's some very small tweaks to make connecting to a ZNC server a little bit easier. This adds a new "bouncer mode" (disabled by default), which displays an additional "Network" input field. When enabled, this sets the password based on ZNC's password format ("username/network:password").

I found it interesting that the code in serverselect.js appears to be using some bits of Backbone, but not its model binding functionality. Is there a reason for this?