### PR TITLE
Update plugin .controlbox textarea for URL

### DIFF
--- a/client/assets/plugins/filepicker.html
+++ b/client/assets/plugins/filepicker.html
@@ -9,7 +9,7 @@
         filepicker.setKey("YOUR_API_KEY");
 
         function uploaded(files) {
-            var area = $("#kiwi #controlbox textarea");
+            var area = $("#kiwi .controlbox textarea");
 
             for (var i = 0; files.length>i; i++) {
                 var f = files[i];


### PR DESCRIPTION
Needed to display the file URL response from the Filepicker API in the input textarea after successful upload.

Fix: Changed #controlbox to .controlbox
