### PR TITLE
Fix French translation of serverselect_nickname

### DIFF
--- a/client/assets/src/translations/fr.po
+++ b/client/assets/src/translations/fr.po
@@ -304,7 +304,7 @@ msgstr "Des gens parlent !"
 
 #: client/assets/src/views/serverselect.js
 msgid "client_views_serverselect_form_title"
-msgstr "Pensez à un pseudonyme…"
+msgstr "Choisissez un pseudonyme :"
 
 #: 
 msgid "client_views_serverselect_nickname"


### PR DESCRIPTION
I don't know if you can say this in English and it's a literal translation, but you can't really say that in French.
