### PR TITLE
Fix a bug with a Chrome + Apache2 mod_proxy setup.

### DIFF
--- a/client/assets/src/index.html.tmpl
+++ b/client/assets/src/index.html.tmpl
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<meta http-equiv="content-script-type" content="text/javascript">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 <base target="_blank">
 


### PR DESCRIPTION
I had a bug with the KiwiIRC server running behind Apache2 with mod_proxy, every requests to .js files received a weird response (The name of the js file was ok but the content was the index.html content O_o )

This fixed it for me. I don't really understand what caused the problem, maybe Chrome was sending bad requests or Apache2 didn't know what to answer, I don't know. I just know that this simple line fixes it.

Source: http://stackoverflow.com/a/1990668
