### PR TITLE
Fix case-sensitivity bug where some received private messages fail to display

### DIFF
--- a/client/assets/src/models/gateway.js
+++ b/client/assets/src/models/gateway.js
@@ -79,7 +79,7 @@ _kiwi.model.Gateway = function () {
         this.on('onmsg', function (event) {
             var source,
                 connection = _kiwi.app.connections.getByConnectionId(event.server),
-                is_pm = (event.channel == connection.get('nick'));
+                is_pm = (event.channel.toLowerCase() == connection.get('nick').toLowerCase());
 
             source = is_pm ? event.nick : event.channel;
 
@@ -105,7 +105,7 @@ _kiwi.model.Gateway = function () {
         this.on('onaction', function (event) {
             var source,
                 connection = _kiwi.app.connections.getByConnectionId(event.server),
-                is_pm = (event.channel == connection.get('nick'));
+                is_pm = (event.channel.toLowerCase() == connection.get('nick').toLowerCase());
 
             source = is_pm ? event.nick : event.channel;
 

--- a/client/assets/src/models/network.js
+++ b/client/assets/src/models/network.js
@@ -353,7 +353,7 @@
 
     function onMsg(event) {
         var panel,
-            is_pm = (event.channel == this.get('nick'));
+            is_pm = (event.channel.toLowerCase() == this.get('nick').toLowerCase());
 
         // An ignored user? don't do anything with it
         if (_kiwi.gateway.isNickIgnored(event.nick)) {
@@ -466,7 +466,7 @@
 
     function onAction(event) {
         var panel,
-            is_pm = (event.channel == this.get('nick'));
+            is_pm = (event.channel.toLowerCase() == this.get('nick').toLowerCase());
 
         // An ignored user? don't do anything with it
         if (_kiwi.gateway.isNickIgnored(event.nick)) {

--- a/server/irc/commands.js
+++ b/server/irc/commands.js
@@ -390,7 +390,7 @@ handlers = {
 
         if ((command.trailing.charAt(0) === String.fromCharCode(1)) && (command.trailing.charAt(command.trailing.length - 1) === String.fromCharCode(1))) {
             // It's a CTCP response
-            namespace = (command.params[0] == this.irc_connection.nick) ? 'user' : 'channel';
+            namespace = (command.params[0].toLowerCase() == this.irc_connection.nick.toLowerCase()) ? 'user' : 'channel';
             this.irc_connection.emit(namespace + ' ' + command.params[0] + ' ctcp_response', {
                 nick: command.nick,
                 ident: command.ident,
@@ -399,7 +399,7 @@ handlers = {
                 msg: command.trailing.substr(1, command.trailing.length - 2)
             });
         } else {
-            namespace = (command.params[0] == this.irc_connection.nick || command.params[0] == '*') ?
+            namespace = (command.params[0].toLowerCase() == this.irc_connection.nick.toLowerCase() || command.params[0] == '*') ?
                 'user' :
                 'channel';
 
@@ -525,7 +525,7 @@ handlers = {
             }
         } else {
             // A message to a user (private message) or to a channel?
-            namespace = (command.params[0] === this.irc_connection.nick) ? 'user ' + command.nick : 'channel ' + command.params[0];
+            namespace = (command.params[0].toLowerCase() == this.irc_connection.nick.toLowerCase()) ? 'user ' + command.nick : 'channel ' + command.params[0];
             this.irc_connection.emit(namespace + ' privmsg', {
                 nick: command.nick,
                 ident: command.ident,


### PR DESCRIPTION
Private messages are distinguished from channel messages by comparing the destination against our own nick, but some of these comparisons were not properly case-insensitive, leading to some incoming messages going missing. Initially experienced intermittently when chatting with Mibbit users on an UnrealIRCd server, but can be reproduced as follows, assuming my nick is KiwiUser and another user issues these commands:

/msg KiwiUser This message works.
/msg kiwiuser This message fails.
