### PR TITLE
Fix improper CTCP parsing

### DIFF
--- a/server/irc/commands.js
+++ b/server/irc/commands.js
@@ -501,7 +501,7 @@ handlers = {
         if ((command.trailing.charAt(0) === String.fromCharCode(1)) && (command.trailing.charAt(command.trailing.length - 1) === String.fromCharCode(1))) {
             //CTCP request
             if (command.trailing.substr(1, 6) === 'ACTION') {
-                this.irc_connection.clientEvent('action', {nick: command.nick, ident: command.ident, hostname: command.hostname, channel: command.params[0], msg: command.trailing.substring(7, command.trailing.length - 1)});
+                this.irc_connection.clientEvent('action', {nick: command.nick, ident: command.ident, hostname: command.hostname, channel: command.params[0], msg: command.trailing.substring(8, command.trailing.length - 1)});
             } else if (command.trailing.substr(1, 4) === 'KIWI') {
                 tmp = command.trailing.substring(6, command.trailing.length - 1);
                 namespace = tmp.split(' ', 1)[0];


### PR DESCRIPTION
The trailing \001 character at the end of incoming CTCP messages was leaking through to the browser in actions, as well as an extra space displayed between the nick and the action.
