### PR TITLE
notifications merge into development take 2 (for real this time)

### DIFF
--- a/client/assets/src/applets/settings.js
+++ b/client/assets/src/applets/settings.js
@@ -3,7 +3,8 @@
         events: {
             'change [data-setting]': 'saveSettings',
             'click [data-setting="theme"]': 'selectTheme',
-            'click .register_protocol': 'registerProtocol'
+            'click .register_protocol': 'registerProtocol',
+	    'click .enable_notifications': 'enableNoticiations'
         },
 
         initialize: function (options) {
@@ -19,14 +20,20 @@
                 default_client: _kiwi.global.i18n.translate('client_applets_settings_default_client').fetch(),
                 make_default: _kiwi.global.i18n.translate('client_applets_settings_default_client_enable').fetch(),
                 locale_restart_needed: _kiwi.global.i18n.translate('client_applets_settings_locale_restart_needed').fetch(),
-                default_note: _kiwi.global.i18n.translate('client_applets_settings_default_client_notice').fetch('<a href="chrome://settings/handlers">chrome://settings/handlers</a>')
+                default_note: _kiwi.global.i18n.translate('client_applets_settings_default_client_notice').fetch('<a href="chrome://settings/handlers">chrome://settings/handlers</a>'),
+		html5_notifications: _kiwi.global.i18n.translate('client_applets_settings_locale_html5_notifications').fetch(),
+		enable_notifications: _kiwi.global.i18n.translate('client_applets_settings_locale_enable_notifications').fetch()
             };
             this.$el = $(_.template($('#tmpl_applet_settings').html().trim(), text));
 
             if (!navigator.registerProtocolHandler) {
                 this.$el.find('.protocol_handler').remove();
             }
-
+/*
+	    if (!window.webkitNotifications) {
+		this.$el.find('notification_enabler').remove();
+	    }
+*/
             // Incase any settings change while we have this open, update them
             _kiwi.global.settings.on('change', this.loadSettings, this);
 
@@ -106,7 +113,12 @@
         registerProtocol: function (event) {
             navigator.registerProtocolHandler('irc', document.location.origin + _kiwi.app.get('base_path') + '/%s', 'Kiwi IRC');
             navigator.registerProtocolHandler('ircs', document.location.origin + _kiwi.app.get('base_path') + '/%s', 'Kiwi IRC');
-        }
+        },
+
+	enableNoticiations: function(event){
+	    window.webkitNotifications.requestPermission();
+	}
+
     });
 
 

--- a/client/assets/src/index.html.tmpl
+++ b/client/assets/src/index.html.tmpl
@@ -266,6 +266,14 @@
                     <small><%= default_note %></small>
                 </div>
             </section>
+
+	    <section class="notification_enabler">
+                <h6><%= html5_notifications %></h6>
+                <div class="control-group">
+                    <button class="enable_notifications"><%= enable_notifications %></button>
+                </div>
+            </section>
+
         </div>
     </script>
 

--- a/client/assets/src/translations/de-de.po
+++ b/client/assets/src/translations/de-de.po
@@ -87,6 +87,14 @@ msgstr "Notiz: Nutzer von Chrome oder Chromium müssen ihre Einstellungen durch 
 msgid "client_applets_settings_title"
 msgstr "Einstellungen"
 
+#:
+msgid "client_applets_settings_locale_html5_notifications"
+msgstr "HTML5 Benachrichtigungen"
+
+#:
+msgid "client_applets_settings_locale_enable_notifications"
+msgstr "Benachrichtigungen einschalten"
+
 #: client/assets/src/models/applet.js
 msgid "client_models_applet_unknown"
 msgstr "Unbekannte Anwendung"

--- a/client/assets/src/translations/en-gb.po
+++ b/client/assets/src/translations/en-gb.po
@@ -87,6 +87,15 @@ msgstr "Note: Chrome or Chromium browser users may need to check their settings 
 msgid "client_applets_settings_title"
 msgstr "Settings"
 
+#:
+msgid "client_apllets_settings_html5_notifications"
+msgstr "HTML5 Notifications"
+
+#:
+msgid "client_apllets_settings_enable_notifications"
+msgstr "Enable notifications"
+
+
 #: client/assets/src/models/applet.js
 msgid "client_models_applet_unknown"
 msgstr "Unknown Applet"

--- a/client/assets/src/views/application.js
+++ b/client/assets/src/views/application.js
@@ -285,5 +285,12 @@ _kiwi.view.Application = Backbone.View.extend({
             return;
         
         soundManager.play(sound_id);
+    },
+
+    showNotification: function(sender, message) {
+    console.log(sender, message);
+	if (window.webkitNotifications && webkitNotifications.checkPermission() === 0){
+	    window.webkitNotifications.createNotification('/kiwi/assets/img/ico.png', sender, message).show();
+	}
     }
 });

--- a/client/assets/src/views/channel.js
+++ b/client/assets/src/views/channel.js
@@ -136,6 +136,7 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
             _kiwi.app.view.alertWindow('* ' + _kiwi.global.i18n.translate('client_views_panel_activity').fetch());
             _kiwi.app.view.favicon.newHighlight();
             _kiwi.app.view.playSound('highlight');
+            _kiwi.app.view.showNotification(msg.nick, msg.msg);
             this.alert('highlight');
 
         } else {


### PR DESCRIPTION
Attempt #2 to make this merge work for development branch. The code that used to be in panel.js now needs to be inserted into channel.js (just one line):

_kiwi.app.view.showNotification(msg.nick, msg.msg);

I inserted this line and did not change panel.js at all from the development branch, resolving that merge conflict.

Hopefully this won't require a third time...
