### PR TITLE
updating example config to match public_html use in httphandler.js

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -53,7 +53,7 @@ conf.identd = {
 
 
 // Where the client files are
-conf.public_http = "client/";
+conf.public_html = "client/";
 
 // Max connections per connection. 0 to disable
 conf.max_client_conns = 5;


### PR DESCRIPTION
in httphandler.js it's using the public_html, not public_http
