### PR TITLE
Fixed typo in config.example.js

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -201,6 +201,6 @@ conf.client = {
 
 
 /*
- * Do not ammend the below lines unless you understand the changes!
+ * Do not amend the below lines unless you understand the changes!
  */
 module.exports.production = conf;


### PR DESCRIPTION
Comment before module export had misspelled 'amend'.
