### PR TITLE
Fix case where params has > 1 whitespace characters.

### DIFF
--- a/server/irc/connection.js
+++ b/server/irc/connection.js
@@ -755,6 +755,6 @@ function parseIrcLine(buffer_line) {
         trailing:   (msg[8]) ? msg[8].trim() : ''
     };
 
-    msg.params = msg.params.split(' ');
+    msg.params = msg.params.split(' ').filter(String);
     this.irc_commands.dispatch(msg.command.toUpperCase(), msg);
 }


### PR DESCRIPTION
This fixes the issue we were talking about on IRC, where if a line of IRC contained multiple whitespace characters between parameters, the parser would fail.
