### PR TITLE
Commandline configuration tweaks

### DIFF
--- a/server/configuration.js
+++ b/server/configuration.js
@@ -28,6 +28,9 @@ Config.prototype.loadConfig = function (manual_config_file) {
 
                     // Try load the new config file
                     new_config = require(manual_config_file);
+
+                    // Save location of configuration file so that we can re-load it later
+                    this.manual_config_file = manual_config_file;
                 }
             } catch (e) {
                 console.log('An error occured parsing the config file ' + manual_config_file + ': ' + e.message);


### PR DESCRIPTION
- Normalise the path given on the command line to enable relative paths
- Store the given path so that the configuration file can be reloaded while Kiwi is running
