### PR TITLE
fix: time parsing variable typo

### DIFF
--- a/server/irc/commands.js
+++ b/server/irc/commands.js
@@ -1017,7 +1017,7 @@ function getServerTime(command) {
         // Convert the time value to a unixtimestamp
         if (typeof time === 'string') {
             if (time.indexOf('T') > -1) {
-                time = parseISO8601(opts.time);
+                time = parseISO8601(time);
 
             } else if(time.match(/^[0-9.]+$/)) {
                 // A string formatted unix timestamp


### PR DESCRIPTION
fix for "ReferenceError: opts is not defined" when KiwiIRC tries to parse an ZNC bufferplayback.
Variable "opts.time" doesn't exist, correct variable is time at this point.
