### PR TITLE
Remove cruft from gateway object

### DIFF
--- a/client/src/models/applet.js
+++ b/client/src/models/applet.js
@@ -1,9 +1,4 @@
 _kiwi.model.Applet = _kiwi.model.Panel.extend({
-    // Used to determine if this is an applet panel. Applet panel tabs are treated
-    // differently than others
-    applet: true,
-
-
     initialize: function (attributes) {
         // Temporary name
         var name = "applet_"+(new Date().getTime().toString()) + Math.ceil(Math.random()*100).toString();
@@ -82,6 +77,10 @@ _kiwi.model.Applet = _kiwi.model.Panel.extend({
         }
 
         this.closePanel();
+    },
+
+    isApplet: function () {
+        return true;
     }
 },
 

--- a/client/src/models/application.js
+++ b/client/src/models/application.js
@@ -610,7 +610,7 @@
 
 
             fn_to_bind['command:ignore'] = function (ev) {
-                var list = _kiwi.gateway.get('ignore_list');
+                var list = this.connections.active_connection.get('ignore_list');
 
                 // No parameters passed so list them
                 if (!ev.params[0]) {
@@ -627,13 +627,13 @@
 
                 // We have a parameter, so add it
                 list.push(ev.params[0]);
-                _kiwi.gateway.set('ignore_list', list);
+                this.connections.active_connection.set('ignore_list', list);
                 _kiwi.app.panels().active.addMsg(' ', _kiwi.global.i18n.translate('client_models_application_ignore_nick').fetch(ev.params[0]));
             };
 
 
             fn_to_bind['command:unignore'] = function (ev) {
-                var list = _kiwi.gateway.get('ignore_list');
+                var list = this.connections.active_connection.get('ignore_list');
 
                 if (!ev.params[0]) {
                     _kiwi.app.panels().active.addMsg(' ', _kiwi.global.i18n.translate('client_models_application_ignore_stop_notice').fetch());
@@ -644,7 +644,7 @@
                     return pattern === ev.params[0];
                 });
 
-                _kiwi.gateway.set('ignore_list', list);
+                this.connections.active_connection.set('ignore_list', list);
 
                 _kiwi.app.panels().active.addMsg(' ', _kiwi.global.i18n.translate('client_models_application_ignore_stopped').fetch(ev.params[0]));
             };
@@ -671,7 +671,7 @@
     function unknownCommand (ev) {
         var raw_cmd = ev.command + ' ' + ev.params.join(' ');
         console.log('RAW: ' + raw_cmd);
-        _kiwi.gateway.raw(null, raw_cmd);
+        this.connections.active_connection.gateway.raw(raw_cmd);
     }
 
     function allCommands (ev) {}
@@ -720,7 +720,7 @@
         message = formatToIrcMsg(ev.params.join(' '));
 
         panel.addMsg(_kiwi.app.connections.active_connection.get('nick'), message);
-        _kiwi.gateway.privmsg(null, destination, message);
+        this.connections.active_connection.gateway.privmsg(destination, message);
     }
 
     function actionCommand (ev) {
@@ -730,21 +730,21 @@
 
         var panel = _kiwi.app.panels().active;
         panel.addMsg('', '* ' + _kiwi.app.connections.active_connection.get('nick') + ' ' + ev.params.join(' '), 'action');
-        _kiwi.gateway.action(null, panel.get('name'), ev.params.join(' '));
+        this.connections.active_connection.gateway.action(panel.get('name'), ev.params.join(' '));
     }
 
     function partCommand (ev) {
         if (ev.params.length === 0) {
-            _kiwi.gateway.part(null, _kiwi.app.panels().active.get('name'));
+            this.connections.active_connection.gateway.part(_kiwi.app.panels().active.get('name'));
         } else {
             _.each(ev.params, function (channel) {
-                _kiwi.gateway.part(null, channel);
+                this.connections.active_connection.gateway.part(channel);
             });
         }
     }
 
     function nickCommand (ev) {
-        _kiwi.gateway.changeNick(null, ev.params[0]);
+        this.connections.active_connection.gateway.changeNick(ev.params[0]);
     }
 
     function topicCommand (ev) {
@@ -759,7 +759,7 @@
             channel_name = _kiwi.app.panels().active.get('name');
         }
 
-        _kiwi.gateway.topic(null, channel_name, ev.params.join(' '));
+        this.connections.active_connection.gateway.topic(channel_name, ev.params.join(' '));
     }
 
     function noticeCommand (ev) {
@@ -771,12 +771,12 @@
         destination = ev.params[0];
         ev.params.shift();
 
-        _kiwi.gateway.notice(null, destination, ev.params.join(' '));
+        this.connections.active_connection.gateway.notice(destination, ev.params.join(' '));
     }
 
     function quoteCommand (ev) {
         var raw = ev.params.join(' ');
-        _kiwi.gateway.raw(null, raw);
+        this.connections.active_connection.gateway.raw(raw);
     }
 
     function kickCommand (ev) {
@@ -790,7 +790,7 @@
         nick = ev.params[0];
         ev.params.shift();
 
-        _kiwi.gateway.kick(null, panel.get('name'), nick, ev.params.join(' '));
+        this.connections.active_connection.gateway.kick(panel.get('name'), nick, ev.params.join(' '));
     }
 
     function clearCommand (ev) {
@@ -816,7 +816,7 @@
         type = ev.params[0];
         ev.params.shift();
 
-        _kiwi.gateway.ctcp(null, true, type, target, ev.params.join(' '));
+        this.connections.active_connection.gateway.ctcp(true, type, target, ev.params.join(' '));
     }
 
     function settingsCommand (ev) {

--- a/client/src/models/channel.js
+++ b/client/src/models/channel.js
@@ -110,5 +110,9 @@ _kiwi.model.Channel = _kiwi.model.Panel.extend({
 
     setMode: function(mode_string) {
         this.get('network').gateway.mode(this.get('name'), mode_string);
+    },
+
+    isChannel: function() {
+        return true;
     }
 });

--- a/client/src/models/gateway.js
+++ b/client/src/models/gateway.js
@@ -3,51 +3,6 @@ _kiwi.model.Gateway = function () {
     // Set to a reference to this object within initialize()
     var that = null;
 
-    this.defaults = {
-        /**
-        *   The name of the network
-        *   @type    String
-        */
-        name: 'Server',
-
-        /**
-        *   The address (URL) of the network
-        *   @type    String
-        */
-        address: '',
-
-        /**
-        *   The current nickname
-        *   @type   String
-        */
-        nick: '',
-
-        /**
-        *   The channel prefix for this network
-        *   @type    String
-        */
-        channel_prefix: '#',
-
-        /**
-        *   The user prefixes for channel owner/admin/op/voice etc. on this network
-        *   @type   Array
-        */
-        user_prefixes: ['~', '&', '@', '+'],
-
-        /**
-        *   The URL to the Kiwi server
-        *   @type   String
-        */
-        kiwi_server: '//kiwi',
-
-        /**
-        *   List of nicks we are ignoring
-        *   @type Array
-        */
-        ignore_list: []
-    };
-
-
     this.initialize = function () {
         that = this;
 
@@ -638,23 +593,6 @@ _kiwi.model.Gateway = function () {
         };
 
         this.sendData(data, callback);
-    };
-
-    // Check a nick alongside our ignore list
-    this.isNickIgnored = function (nick) {
-        var idx, list = this.get('ignore_list');
-        var pattern, regex;
-
-        for (idx = 0; idx < list.length; idx++) {
-            pattern = list[idx].replace(/([.+^$[\]\\(){}|-])/g, "\\$1")
-                .replace('*', '.*')
-                .replace('?', '.');
-
-            regex = new RegExp(pattern, 'i');
-            if (regex.test(nick)) return true;
-        }
-
-        return false;
     };
 
 

--- a/client/src/models/network.js
+++ b/client/src/models/network.js
@@ -49,7 +49,13 @@
             *   The user prefixes for channel owner/admin/op/voice etc. on this network
             *   @type   Array
             */
-            user_prefixes: ['~', '&', '@', '+']
+            user_prefixes: ['~', '&', '@', '+'],
+
+            /**
+            *   List of nicks we are ignoring
+            *   @type Array
+            */
+            ignore_list: []
         },
 
 
@@ -163,7 +169,7 @@
                 channel_name = channel_name.trim();
 
                 // If not a valid channel name, display a warning
-                if (!_kiwi.app.isChannelName(channel_name)) {
+                if (!that.isChannelName(channel_name)) {
                     that.panels.server.addMsg('', _kiwi.global.i18n.translate('client_models_network_channel_invalid_name').fetch(channel_name));
                     _kiwi.app.message.text(_kiwi.global.i18n.translate('client_models_network_channel_invalid_name').fetch(channel_name), {timeout: 5000});
                     return;
@@ -198,6 +204,30 @@
 
                 that.gateway.join(panel.get('name'));
             });
+        },
+
+        isChannelName: function (channel_name) {
+            var channel_prefix = this.get('channel_prefix');
+
+            if (!channel_name || !channel_name.length) return false;
+            return (channel_prefix.indexOf(channel_name[0]) > -1);
+        },
+
+        // Check a nick alongside our ignore list
+        isNickIgnored: function (nick) {
+            var idx, list = this.get('ignore_list');
+            var pattern, regex;
+
+            for (idx = 0; idx < list.length; idx++) {
+                pattern = list[idx].replace(/([.+^$[\]\\(){}|-])/g, "\\$1")
+                    .replace('*', '.*')
+                    .replace('?', '.');
+
+                regex = new RegExp(pattern, 'i');
+                if (regex.test(nick)) return true;
+            }
+
+            return false;
         }
     });
 
@@ -362,7 +392,7 @@
             is_pm = (event.channel.toLowerCase() == this.get('nick').toLowerCase());
 
         // An ignored user? don't do anything with it
-        if (_kiwi.gateway.isNickIgnored(event.nick)) {
+        if (this.isNickIgnored(event.nick)) {
             return;
         }
 
@@ -409,7 +439,7 @@
 
     function onCtcpRequest(event) {
         // An ignored user? don't do anything with it
-        if (_kiwi.gateway.isNickIgnored(event.nick)) {
+        if (this.isNickIgnored(event.nick)) {
             return;
         }
 
@@ -423,7 +453,7 @@
 
     function onCtcpResponse(event) {
         // An ignored user? don't do anything with it
-        if (_kiwi.gateway.isNickIgnored(event.nick)) {
+        if (this.isNickIgnored(event.nick)) {
             return;
         }
 
@@ -436,7 +466,7 @@
         var panel, channel_name;
 
         // An ignored user? don't do anything with it
-        if (!event.from_server && event.nick && _kiwi.gateway.isNickIgnored(event.nick)) {
+        if (!event.from_server && event.nick && this.isNickIgnored(event.nick)) {
             return;
         }
 
@@ -475,7 +505,7 @@
             is_pm = (event.channel.toLowerCase() == this.get('nick').toLowerCase());
 
         // An ignored user? don't do anything with it
-        if (_kiwi.gateway.isNickIgnored(event.nick)) {
+        if (this.isNickIgnored(event.nick)) {
             return;
         }
 

--- a/client/src/models/panel.js
+++ b/client/src/models/panel.js
@@ -39,27 +39,19 @@ _kiwi.model.Panel = Backbone.Model.extend({
     },
 
     isChannel: function () {
-        var channel_prefix = _kiwi.gateway.get('channel_prefix'),
-            this_name = this.get('name');
-
-        if (this.isApplet() || !this_name) return false;
-        return (channel_prefix.indexOf(this_name[0]) > -1);
+        return false;
     },
 
     isQuery: function () {
-        if (!this.isChannel() && !this.isApplet() && !this.isServer()) {
-            return true;
-        }
-
         return false;
     },
 
     isApplet: function () {
-        return this.applet ? true : false;
+        return false;
     },
 
     isServer: function () {
-        return this.server ? true : false;
+        return false;
     },
 
     isActive: function () {

--- a/client/src/models/query.js
+++ b/client/src/models/query.js
@@ -8,5 +8,13 @@ _kiwi.model.Query = _kiwi.model.Channel.extend({
             "name": name,
             "scrollback": []
         }, {"silent": true});
+    },
+
+    isChannel: function () {
+        return false;
+    },
+
+    isQuery: function () {
+        return true;
     }
 });

--- a/client/src/models/server.js
+++ b/client/src/models/server.js
@@ -1,7 +1,4 @@
 _kiwi.model.Server = _kiwi.model.Channel.extend({
-    // Used to determine if this is a server panel
-    server: true,
-
     initialize: function (attributes) {
         var name = "Server";
         this.view = new _kiwi.view.Channel({"model": this, "name": name});
@@ -11,5 +8,13 @@ _kiwi.model.Server = _kiwi.model.Channel.extend({
         }, {"silent": true});
 
         //this.addMsg(' ', '--> Kiwi IRC: Such an awesome IRC client', '', {style: 'color:#009900;'});
+    },
+
+    isServer: function () {
+        return true;
+    },
+
+    isChannel: function () {
+        return false;
     }
 });

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -58,7 +58,8 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
             nick_colour_hex, nick_hex, is_highlight, msg_css_classes = '',
             time_difference,
             sb = this.model.get('scrollback'),
-            prev_msg = sb[sb.length-2];
+            prev_msg = sb[sb.length-2],
+            network;
 
         // Nick highlight detecting
         if ((new RegExp('(^|\\W)(' + escapeRegex(_kiwi.app.connections.active_connection.get('nick')) + ')(\\W|$)', 'i')).test(msg.msg)) {
@@ -70,10 +71,12 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
         msg.msg =  $('<div />').text(msg.msg).html();
 
         // Make the channels clickable
-        re = new RegExp('(?:^|\\s)([' + escapeRegex(_kiwi.gateway.get('channel_prefix')) + '][^ ,\\007]+)', 'g');
-        msg.msg = msg.msg.replace(re, function (match) {
-            return '<a class="chan" data-channel="' + match.trim() + '">' + match + '</a>';
-        });
+        if ((network = this.model.get('network'))) {
+        re = new RegExp('(?:^|\\s)([' + escapeRegex(network.get('channel_prefix')) + '][^ ,\\007]+)', 'g');
+            msg.msg = msg.msg.replace(re, function (match) {
+                return '<a class="chan" data-channel="' + match.trim() + '">' + match + '</a>';
+            });
+        }
 
 
         // Parse any links found
@@ -275,12 +278,9 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
 
 
     chanClick: function (event) {
-        if (event.target) {
-            _kiwi.gateway.join(null, $(event.target).data('channel'));
-        } else {
-            // IE...
-            _kiwi.gateway.join(null, $(event.srcElement).data('channel'));
-        }
+        var target = (event.target) ? $(event.target).data('channel') : $(event.srcElement).data('channel');
+
+        _kiwi.app.connections.active_connection.gateway.join(target);
     },
 
 

--- a/client/src/views/channeltools.js
+++ b/client/src/views/channeltools.js
@@ -11,6 +11,6 @@ _kiwi.view.ChannelTools = Backbone.View.extend({
     },
 
     partClick: function (event) {
-        _kiwi.gateway.part(null, _kiwi.app.panels().active.get('name'));
+        _kiwi.app.connections.active_connection.gateway.part(_kiwi.app.panels().active.get('name'));
     }
 });

--- a/client/src/views/topicbar.js
+++ b/client/src/views/topicbar.js
@@ -29,7 +29,7 @@ _kiwi.view.TopicBar = Backbone.View.extend({
 
         // If hit return key, update the current topic
         if (ev.keyCode === 13) {
-            _kiwi.gateway.topic(null, _kiwi.app.panels().active.get('name'), inp_val);
+            _kiwi.app.connections.active_connection.gateway.topic(_kiwi.app.panels().active.get('name'), inp_val);
             return false;
         }
     },


### PR DESCRIPTION
Things that should be Network-local now look for properties on the Network
object rather than on the Gateway object.

client-side ignore functionality is now per-network rather than global.
