### PR TITLE
Fall back to last tab after closing another #381

### DIFF
--- a/client/src/models/application.js
+++ b/client/src/models/application.js
@@ -127,7 +127,7 @@ _kiwi.model.Application = function () {
             this.message = new _kiwi.view.StatusMessage({el: this.view.$el.find('.status_message')[0]});
 
             this.resize_handle = new _kiwi.view.ResizeHandler({el: this.view.$el.find('.memberlists_resize_handle')[0]});
-            
+
             // Rejigg the UI sizes
             this.view.doLayout();
         };

--- a/client/src/views/networktabs.js
+++ b/client/src/views/networktabs.js
@@ -18,7 +18,7 @@ _kiwi.view.NetworkTabs = Backbone.View.extend({
 
     networkRemoved: function(network) {
         network.panels.view.remove();
-        
+
         _kiwi.app.view.doLayout();
     }
 });

--- a/client/src/views/tabs.js
+++ b/client/src/views/tabs.js
@@ -88,21 +88,20 @@ _kiwi.view.Tabs = Backbone.View.extend({
         _kiwi.app.view.doLayout();
     },
     panelRemoved: function (panel) {
-        var that = this;
+        var connection = _kiwi.app.connections.active_connection;
 
         panel.tab.remove();
-
-        var connection = _kiwi.app.connections.active_connection;
 
         // If closing the active panel, switch to the last-accessed panel
         if (this.panel_access[0] === _kiwi.app.panels().active.cid) {
             this.panel_access.shift();
 
-            _.forEach(connection.panels.models, function(model) {
-                if (model.cid === that.panel_access[0]) {
-                    model.view.show();
-                }
-            });
+            //Get the last-accessed panel model now that we removed the closed one
+            var model = connection.panels.getByCid(this.panel_access[0]);
+
+            if (model) {
+                model.view.show();
+            }
         }
 
         delete panel.tab;
@@ -111,6 +110,8 @@ _kiwi.view.Tabs = Backbone.View.extend({
     },
 
     panelActive: function (panel, previously_active_panel) {
+        var panel_index = this.panel_access.indexOf(panel.cid);
+
         // Remove any existing tabs or part images
         _kiwi.app.view.$el.find('.panellist .part').remove();
         _kiwi.app.view.$el.find('.panellist .active').removeClass('active');
@@ -122,7 +123,6 @@ _kiwi.view.Tabs = Backbone.View.extend({
             panel.tab.append('<span class="part icon-nonexistant"></span>');
         }
 
-        var panel_index = this.panel_access.indexOf(panel.cid);
         if (panel_index > -1) {
             this.panel_access.splice(panel_index, 1);
         }


### PR DESCRIPTION
Regarding issue #381, this pull request deals with falling back to the last tab accessed after the active tab has been closed. This does not work with the settings tab, because unfortunately the settings tab is a different kind of tab. See issue #479 for more details.
