### PR TITLE
show/hide userslist #459

### DIFF
--- a/client/src/index.html.tmpl
+++ b/client/src/index.html.tmpl
@@ -22,6 +22,7 @@
             <div class="toolbar">
                 <div class="app_tools">
                     <ul class="main">
+                        <li class="hiderightbar"><i class="icon-eye-close" title="Hide Members List"></i></li>
                         <li class="settings"><i class="icon-cogs" title="Settings"></i></li>
                         <li class="startup"><i class="icon-home" title="Home"></i></li>
                         <li><a href="https://kiwiirc.com/" target="_blank"><img src="<%base_path%>/assets/img/ico.png" alt="KiwiIRC" title="KiwiIRC" /></a></li>

--- a/client/src/views/apptoolbar.js
+++ b/client/src/views/apptoolbar.js
@@ -1,7 +1,8 @@
 _kiwi.view.AppToolbar = Backbone.View.extend({
     events: {
         'click .settings': 'clickSettings',
-        'click .startup': 'clickStartup'
+        'click .startup': 'clickStartup' ,
+        'click .hiderightbar': 'clickHideRightBar'
     },
 
     initialize: function () {
@@ -20,4 +21,11 @@ _kiwi.view.AppToolbar = Backbone.View.extend({
         event.preventDefault();
         _kiwi.app.startup_applet.view.show();
     },
+
+    clickHideRightBar: function (event) {
+        event.preventDefault();
+        $(".right_bar").toggle();
+        $(".memberlists_resize_handle").toggle();
+        _kiwi.app.view.doLayout();
+    }
 });


### PR DESCRIPTION
Added an icon in the index.html.tmpl underneath app_tools. I decided to add it there so that the entire right_bar can be hidden and then unhidden easily. 
I added the event handler for the icon in apptoolbar.js. I decided to use .toggle() because toggleClass() was removing the styles for right_bar, but keeping the styles for memberlists and toolbar. The toggle method simply sets the div's css display to none, so this seemed like the best choice. 
