### PR TITLE
Small cleanup of server/irc/connection.js

### DIFF
--- a/server/irc/connection.js
+++ b/server/irc/connection.js
@@ -20,7 +20,7 @@ var version_values = process.version.substr(1).split('.').map(function (item) {
     return parseInt(item, 10);
 });
 
-// If we have a suitable Nodejs version, bring int he socks functionality
+// If we have a suitable Nodejs version, bring in the SOCKS functionality
 if (version_values[1] >= 10) {
     Socks = require('socksjs');
 }


### PR DESCRIPTION
- Fix global variable leakage (ae3506f)
- Add missing braces (e8c4bb7)
- Remove superfluous local variables and pass had_error to close event (9478bac)
- Use strict equality (`===`) instead of coercive equality (`==`) (353d261)
- Fix typo in comment (0c0dfa9)
