### PR TITLE
Patching XSS vulnerability

### DIFF
--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -88,6 +88,10 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
             var nice = url,
                 extra_html = '';
 
+            if (url.match(/^javascript:/)) {
+                return url;
+            }
+
             // Add the http if no protoocol was found
             if (url.match(/^www\./)) {
                 url = 'http://' + url;


### PR DESCRIPTION
The following message produces a clickable link that triggers JavaScript when clicked (pre-patch):
`javascript://www.google.com/?%0Aalert(0);`

Patch was designed to prevent this while maintaining support for arbitrary link protocols.
