### PR TITLE
Added possibility to lock channels (i.e. prevent parting) (and css classes for channels)

### DIFF
--- a/client/src/models/channel.js
+++ b/client/src/models/channel.js
@@ -114,5 +114,10 @@ _kiwi.model.Channel = _kiwi.model.Panel.extend({
 
     isChannel: function() {
         return true;
+    },
+
+    isLocked: function() {
+	return _kiwi.global.defaultServerSettings().channel == this.get('name') || 
+	      (_kiwi.app.server_settings.client.locked_channels.indexOf(this.get('name')) >= 0);
     }
 });

--- a/client/src/models/panel.js
+++ b/client/src/models/panel.js
@@ -37,6 +37,10 @@ _kiwi.model.Panel = Backbone.Model.extend({
         return false;
     },
 
+    isLocked: function() {
+        return false;
+    },
+
     isQuery: function () {
         return false;
     },

--- a/client/src/views/tabs.js
+++ b/client/src/views/tabs.js
@@ -65,7 +65,15 @@ _kiwi.view.Tabs = Backbone.View.extend({
 
     panelAdded: function (panel) {
         // Add a tab to the panel
-        panel.tab = $('<li><span>' + (panel.get('title') || panel.get('name')) + '</span><div class="activity"></div></li>');
+	var name = (panel.get('title') || panel.get('name'));
+	var name_css = name.replace("#", "").replace(/[^a-z0-9]/g, function(s) {
+          var c = s.charCodeAt(0);
+          if (c == 32) return '-';
+          if (c >= 65 && c <= 90) return '_' + s.toLowerCase();
+	  return "";
+        });
+        
+	panel.tab = $('<li class="channel-'+name_css+'"><span>' + name + '</span><div class="activity"></div></li>');
 
         if (panel.isServer()) {
             panel.tab.addClass('server');
@@ -117,9 +125,9 @@ _kiwi.view.Tabs = Backbone.View.extend({
         _kiwi.app.view.$el.find('.panellist .active').removeClass('active');
 
         panel.tab.addClass('active');
-
+	
         // Only show the part image on non-server tabs
-        if (!panel.isServer()) {
+        if (!panel.isServer() && !panel.isLocked()) {
             panel.tab.append('<span class="part icon-nonexistant"></span>');
         }
 

--- a/config.example.js
+++ b/config.example.js
@@ -187,7 +187,8 @@ conf.client = {
         show_emoticons: true,
         count_all_activity: true
     },
-    window_title: 'Kiwi IRC'
+    window_title: 'Kiwi IRC',
+    locked_channels: [] // Channel passed via URL hash (i.e. #mychannel) is automatically locked
 };
 
 // List of themes available for the user to choose from


### PR DESCRIPTION
Hi there !

I added (for my own use) the possibility to lock people in certain channels. So, why not share it.

Locking is simple and just do not show the part button.

Channel passed through the URL as a hash is automatically locked.

Nice work,
Regards.
