### PR TITLE
Add ability to close network tabs

### DIFF
--- a/client/src/views/tabs.js
+++ b/client/src/views/tabs.js
@@ -139,7 +139,7 @@ _kiwi.view.Tabs = Backbone.View.extend({
                 if(confirmed) {
                     this.model.network.gateway.quit("Leaving");
                     _kiwi.app.connections.remove(this.model.network);
-                    window.location.reload(true);
+                    _kiwi.app.startup_applet.view.show();
                 }
             } else {
                 this.model.network.gateway.quit("Leaving");


### PR DESCRIPTION
Proposal for #613 
This allows closing of network tabs similar to channel tabs, but it will close out all associated channels to network first. Closing the last network tab will redirect to the client homepage.

Issues:
Part icon ( [x] ) on the Relaxed theme does not render correctly.
