### PR TITLE
Code style fixes

### DIFF
--- a/client/src/applets/settings.js
+++ b/client/src/applets/settings.js
@@ -37,7 +37,7 @@
             }
 
             if (!(window.Notification || window.webkitNotifications || navigator.mozNotification)) {
-                this.$('notification_enabler').remove();
+                this.$('.notification_enabler').remove();
             }
 
             // Incase any settings change while we have this open, update them


### PR DESCRIPTION
Sorry for the completely generic title here. This makes one functional change, and a couple of code style changes to settings.js
- the notifications checkbox was only enabled if `webkitNotifications` was on window. Chrome has removed this (and Firefox its equivalent too), so the correct condition should include these. I didn't remove the check on the `webkitNotifications` property, since I don't know how much old browser support you want to keep. It's been a while since it was removed anyway, so I think it could go.

Code style changes:
- The use of `this.$('...')` vs `$('...', this.$el)` was inconsistent. I changed to use the former since it's shorter and a standard backbone method
- There was a lot of repeated code in the translations that was shortened with a small helper function
- Typo in one of the method names.
