### PR TITLE
Abstract desktop notifications to a class

### DIFF
--- a/client/src/applets/settings.js
+++ b/client/src/applets/settings.js
@@ -4,7 +4,7 @@
             'change [data-setting]': 'saveSettings',
             'click [data-setting="theme"]': 'selectTheme',
             'click .register_protocol': 'registerProtocol',
-            'click .enable_notifications': 'enableNoticiations'
+            'click .enable_notifications': 'enableNotifications'
         },
 
         initialize: function (options) {
@@ -36,8 +36,9 @@
                 this.$el.find('.protocol_handler').remove();
             }
 
-            if (!window.webkitNotifications) {
-                this.$el.find('notification_enabler').remove();
+
+            if (_kiwi.global.utils.notifications.allowed() !== null) {
+                this.$el.find('.notification_enabler').remove();
             }
 
             // Incase any settings change while we have this open, update them
@@ -124,14 +125,14 @@
             navigator.registerProtocolHandler('ircs', document.location.origin + _kiwi.app.get('base_path') + '/%s', 'Kiwi IRC');
         },
 
-        enableNoticiations: function(event){
+        enableNotifications: function(event){
             event.preventDefault();
-
-            if ('webkitNotifications' in window) {
-                window.webkitNotifications.requestPermission();
-            } else if ('Notification' in window) {
-                Notification.requestPermission();
-            }
+            var notifications = _kiwi.global.utils.notifications;
+            notifications.requestPermission().always(_.bind(function () {
+                if (notifications.allowed() !== null) {
+                    this.$('.notification_enabler').remove();
+                }
+            }, this));
         }
 
     });

--- a/client/src/helpers/desktopnotifications.js
+++ b/client/src/helpers/desktopnotifications.js
@@ -1,0 +1,126 @@
+_kiwi.global.utils.notifications = (function () {
+    if (!window.Notification) {
+        return {
+            allowed: _.constant(false),
+            requestPermission: _.constant($.Deferred().reject())
+        };
+    }
+
+    var notifications = {
+        /**
+         * Check if desktop notifications have been allowed by the user.
+         *
+         * @returns {?Boolean} `true`  - they have been allowed.
+         *                     `false` - they have been blocked.
+         *                     `null`  - the user hasn't answered yet.
+         */
+        allowed: function () {
+            return Notification.permission === 'granted' ? true
+                 : Notification.permission === 'denied' ? false
+                 : null;
+        },
+
+        /**
+         * Ask the user their permission to display desktop notifications.
+         * This will return a promise which will be resolved if the user allows notifications, or rejected if they blocked
+         * notifictions or simply closed the dialog. If the user had previously given their preference, the promise will be
+         * immediately resolved or rejected with their previous answer.
+         *
+         * @example
+         *   notifications.requestPermission().then(function () { 'allowed' }, function () { 'not allowed' });
+         *
+         * @returns {Promise}
+         */
+        requestPermission: function () {
+            var deferred = $.Deferred();
+            Notification.requestPermission(function (permission) {
+                deferred[(permission === 'granted') ? 'resolve' : 'reject']();
+            });
+            return deferred.promise();
+        },
+
+        /**
+         * Create a new notification. If the user has not yet given permission to display notifications, they will be asked
+         * to confirm first. The notification will show afterwards if they allow it.
+         *
+         * Notifications implement Backbone.Events (so you can use `on` and `off`). They trigger four different events:
+         *   - 'click'
+         *   - 'close'
+         *   - 'error'
+         *   - 'show'
+         *
+         * @example
+         *   notifications
+         *     .create('Cool notification', { icon: 'logo.png' })
+         *     .on('click', function () {
+         *       window.focus();
+         *     })
+         *     .closeAfter(5000);
+         *
+         * @param   {String}  title
+         * @param   {Object}  options
+         * @param   {String=} options.body  A string representing an extra content to display within the notification
+         * @param   {String=} options.dir   The direction of the notification; it can be auto, ltr, or rtl
+         * @param   {String=} options.lang  Specify the lang used within the notification. This string must be a valid BCP
+         *                                  47 language tag.
+         * @param   {String=} options.tag   An ID for a given notification that allows to retrieve, replace or remove it if necessary
+         * @param   {String=} options.icon  The URL of an image to be used as an icon by the notification
+         * @returns {Notifier}
+         */
+        create: function (title, options) {
+            return new Notifier(title, options);
+        }
+    };
+
+    function Notifier(title, options) {
+        createNotification.call(this, title, options);
+    }
+    _.extend(Notifier.prototype, Backbone.Events, {
+        closed: false,
+        _closeTimeout: null,
+
+        /**
+         * Close the notification after a given number of milliseconds.
+         * @param   {Number} timeout
+         * @returns {this}
+         */
+        closeAfter: function (timeout) {
+            if (!this.closed) {
+                if (this.notification) {
+                    this._closeTimeout = this._closeTimeout || setTimeout(_.bind(this.close, this), timeout);
+                } else {
+                    this.once('show', _.bind(this.closeAfter, this, timeout));
+                }
+            }
+            return this;
+        },
+
+        /**
+         * Close the notification immediately.
+         * @returns {this}
+         */
+        close: function () {
+            if (this.notification && !this.closed) {
+                this.notification.close();
+                this.closed = true;
+            }
+            return this;
+        }
+    });
+
+    function createNotification(title, options) {
+        switch (notifications.allowed()) {
+            case true:
+                this.notification = new Notification(title, options);
+                _.each(['click', 'close', 'error', 'show'], function (eventName) {
+                    this.notification['on' + eventName] = _.bind(this.trigger, this, eventName);
+                }, this);
+                break;
+            case null:
+                notifications.requestPermission().done(_.bind(createNotification, this, title, options));
+                break;
+        }
+    }
+
+    return notifications;
+}());

--- a/client/src/views/application.js
+++ b/client/src/views/application.js
@@ -345,30 +345,14 @@ _kiwi.view.Application = Backbone.View.extend({
 
     showNotification: function(title, message) {
         var icon = this.model.get('base_path') + '/assets/img/ico.png',
-            notification;
+            notifications = _kiwi.global.utils.notifications;
 
-        if (this.has_focus)
-            return;
-
-        // Different versions of Chrome/firefox have different implimentations
-        if ('Notification' in window && Notification.permission && Notification.permission === 'granted') {
-            notification = new Notification(title, {icon: icon, body: message});
-
-        } else if ('webkitNotifications' in window && webkitNotifications.checkPermission() === 0) {
-            notification = window.webkitNotifications.createNotification(icon, title, message);
-
-        } else if ('mozNotification' in navigator) {
-            notification = navigator.mozNotification.createNotification(title, message, icon);
+        if (!this.has_focus && notifications.allowed()) {
+            notifications
+                .create(title, { icon: icon, body: message })
+                .closeAfter(5000)
+                .on('click', _.bind(window.focus, window));
         }
-
-        if (!notification) {
-            // Couldn't find any notification support
-            return;
-        }
-
-        setTimeout(function() {
-            (notification.cancel || notification.close).call(notification);
-        }, 5000);
     },
 
     monitorPanelFallback: function() {


### PR DESCRIPTION
The state of the desktop notifications is a bit weird. There's duplicated code checking for browser support (differently in each case), and a few bugs with hiding the settings.

This PR abstracts the code to a helper class and provides a simple interface for creating and closing notifications.

``` js
// example usage:
_kiwi.global.utils.notifications
  .create('Title', { icon: 'icon.png', body: 'Body text' })
  .closeAfter(5000)
  .on('close', function () { doSomething(); });
```

Important things to note:
- this drops support for `window.webkitNotifications` and `navigator.mozNotification`, since Chrome and Firefox also dropped that support a while back.
- there's no fallback for IE. Not much you can really do about that...
- clicking the notification will focus the KiwiIRC tab
- If the user has previously allowed or blocked desktop notifications, there's nothing you can do from the code to override that or ask them again. In this case, I hide the button on the settings page, since it _can't_ do anything. Perhaps what would be nicer would be to display a message says "Desktop notifications are enabled/disabled." along with instructions on how to change that (in case you accidentally blocked it once and want to change it). The only problem though is that it would require some new language strings, and I don't know the process for that, so I just left it out.
