### PR TITLE
Add custom highlight words

### DIFF
--- a/client/src/applets/settings.js
+++ b/client/src/applets/settings.js
@@ -26,6 +26,7 @@
                 default_note          : translateText('client_applets_settings_default_client_notice', '<a href="chrome://settings/handlers">chrome://settings/handlers</a>'),
                 html5_notifications   : translateText('client_applets_settings_html5_notifications'),
                 enable_notifications  : translateText('client_applets_settings_enable_notifications'),
+                custom_highlights     : translateText('client_applets_settings_custom_highlights'),
                 theme_thumbnails: _.map(_kiwi.app.themes, function (theme) {
                     return _.template($('#tmpl_theme_thumbnail').html().trim(), theme);
                 })

--- a/client/src/index.html.tmpl
+++ b/client/src/index.html.tmpl
@@ -311,10 +311,18 @@
                                 <%= emoticons %>
                             </label>
                         </div>
-                        <label>
-                            <input data-setting="scrollback" class="input-small" type="text" size="4" pattern="\d*">
-                            <span><%= scroll_history %></span>
-                        </label>
+                        <div>
+                            <label>
+                                <input data-setting="scrollback" class="input-small" type="text" size="4" pattern="\d*">
+                                <span><%= scroll_history %></span>
+                            </label>
+                        </div>
+                        <div>
+                            <label>
+                                <div><%= custom_highlights %></div>
+                                <input data-setting="custom_highlights" class="input-small" type="text" size="20">
+                            </label>
+                        </div>
                     </div>
                 </section>
 

--- a/client/src/translations/en-gb.po
+++ b/client/src/translations/en-gb.po
@@ -77,6 +77,10 @@ msgid "client_applets_settings_history_length"
 msgstr "messages in scroll history"
 
 #: 
+msgid "client_applets_settings_custom_highlights"
+msgstr "Custom highlights (space separated)"
+
+#: 
 msgid "client_applets_settings_default_client"
 msgstr "Default IRC client"
 

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -296,7 +296,7 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
                 .join('|')
                 .value();
 
-            if (msg.msg.search(new RegExp('\\b(' + regexpStr + ')\\b', 'i')) > -1) {
+            if (msg.msg.search(new RegExp('(\\b|\\W|^)(' + regexpStr + ')(\\b|\\W|$)', 'i')) > -1) {
                 msg.is_highlight = true;
                 msg.css_classes += ' highlight';
             }

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -269,7 +269,7 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
             message_words,
             sb = this.model.get('scrollback'),
             nick,
-            highlight,
+            regexpStr,
             prev_msg = sb[sb.length-2],
             hour, pm, am_pm_locale_key;
 
@@ -284,18 +284,18 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
 
         // Nick + custom highlight detecting
         nick = _kiwi.app.connections.active_connection.get('nick');
-        highlight = msg.nick.localeCompare(nick) !== 0
-            && _.chain((_kiwi.global.settings.get('custom_highlights') || '').split(/[\s,]+/))
-                .concat(nick)
+        if (msg.nick.localeCompare(nick) !== 0) {
+            regexpStr = _.chain((_kiwi.global.settings.get('custom_highlights') || '').split(/[\s,]+/))
                 .compact()
-                .some(function (word) {
-                    return (new RegExp('\\b' + escapeRegex(word) + '\\b', 'i')).test(msg.msg);
-                })
+                .concat(nick)
+                .map(escapeRegex)
+                .join('|')
                 .value();
 
-        if (highlight) {
-            msg.is_highlight = true;
-            msg.css_classes += ' highlight';
+            if (msg.msg.search('\\b(' + regexpStr + ')\\b', 'i') > -1) {
+                msg.is_highlight = true;
+                msg.css_classes += ' highlight';
+            }
         }
 
         message_words = msg.msg.split(/\s+/);

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -296,7 +296,7 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
                 .join('|')
                 .value();
 
-            if (msg.msg.search('\\b(' + regexpStr + ')\\b', 'i') > -1) {
+            if (msg.msg.search(new RegExp('\\b(' + regexpStr + ')\\b', 'i')) > -1) {
                 msg.is_highlight = true;
                 msg.css_classes += ' highlight';
             }

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -242,25 +242,29 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
     },
 
 
-    // Sgnerate a css style for a nick
-    getNickStyles: function(nick) {
-        var ret, colour, nick_int = 0, rgb;
+    // Generate a css style for a nick
+    getNickStyles: (function () {
 
         // Get a colour from a nick (Method based on IRSSIs nickcolor.pl)
-        _.map(nick.split(''), function (i) { nick_int += i.charCodeAt(0); });
-        rgb = hsl2rgb(nick_int % 255, 70, 35);
-        rgb = rgb[2] | (rgb[1] << 8) | (rgb[0] << 16);
-        colour = '#' + rgb.toString(16);
+        return function (nick) {
+            var nick_int = _.reduce(nick.split(''), sumCharCodes, 0),
+                rgb = hsl2rgb(nick_int % 256, 70, 35);
 
-        ret = {color: colour};
-        ret.asCssString = function() {
-            return _.reduce(this, function(result, item, key){
-                return result + key + ':' + item + ';';
-            }, '');
+            return {
+                color: '#' + ('000000' + (rgb[2] | (rgb[1] << 8) | (rgb[0] << 16)).toString(16)).substr(-6),
+                asCssString: asCssString
+            };
         };
-
-        return ret;
-    },
+        function toCssProperty(result, item, key) {
+            return result + (typeof item === 'string' || typeof item === 'number' ? key + ':' + item + ';' : '');
+        }
+        function asCssString() {
+            return _.reduce(this, toCssProperty, '');
+        }
+        function sumCharCodes(total, i) {
+            return total + i.charCodeAt(0);
+        }
+    }()),
 
 
     // Takes an IRC message object and parses it for displaying


### PR DESCRIPTION
This PR allows users to specify any number of words which they should be highlighted on. Here's a typical usage:

![selection_012](https://cloud.githubusercontent.com/assets/426222/5488098/9faa7c5e-86b9-11e4-814a-fbbc947f3176.png)

And then it behaves just like a regular nick mention:

![selection_013](https://cloud.githubusercontent.com/assets/426222/5488100/a147227e-86b9-11e4-9d84-949db4dc5b5f.png)

The only question I have here is what to do about the translations? I added the string to en-gb, but none of the others.