### PR TITLE
Add SoundCloud embedding

### DIFF
--- a/client/src/views/mediamessage.js
+++ b/client/src/views/mediamessage.js
@@ -164,7 +164,7 @@ _kiwi.view.MediaMessage = Backbone.View.extend({
 
         soundcloud: function () {
             var url = this.$el.data('url'),
-                $content = this.$content.find('.content');
+                $content = $('<div></div>').text(_kiwi.global.i18n.translate('client_models_applet_loading').fetch());
 
             $.getJSON('http://soundcloud.com/oembed', { url: url })
                 .then(function (data) {
@@ -172,10 +172,10 @@ _kiwi.view.MediaMessage = Backbone.View.extend({
                         $(data.html).attr('height', data.height - 100)
                     );
                 }, function () {
-                    $content.html(_kiwi.global.i18n.translate('client_views_mediamessage_notfound').fetch());
+                    $content.text(_kiwi.global.i18n.translate('client_views_mediamessage_notfound').fetch());
                 });
 
-            return _kiwi.global.i18n.translate('client_models_applet_loading').fetch();
+            return $content;
         },
 
         custom: function() {


### PR DESCRIPTION
Works on urls like:
- soundcloud.com/:username
- soundcloud.com/:username/:track
- soundcloud.com/:username/sets/:playlist
- soundcloud.com/groups/:groupName

Some examples
![selection_014](https://cloud.githubusercontent.com/assets/426222/5498509/31168d84-8720-11e4-9111-1e17abd47f78.png)
![selection_016](https://cloud.githubusercontent.com/assets/426222/5498547/b38bbcc6-8720-11e4-8c19-199976b49dd5.png)
