### PR TITLE
Highlight nicks also when they have punctuation surrounding them

### DIFF
--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -157,28 +157,26 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
 
     // Let nicks be clickable + colourise within messages
     parseMessageNicks: function(word, colourise) {
-        var members, member, style = '';
+        var members, member, nick, nickRe, style = '';
 
-        members = this.model.get('members');
-        if (!members) {
+        if (!(members = this.model.get('members')) || !(member = members.getByNick(word))) {
             return;
         }
 
-        member = members.getByNick(word);
-        if (!member) {
-            return;
-        }
+        nick = member.get('nick');
 
         if (colourise !== false) {
             // Use the nick from the member object so the style matches the letter casing
-            style = this.getNickStyles(member.get('nick')).asCssString();
+            style = this.getNickStyles(nick).asCssString();
         }
-
-        return _.template('<span class="inline-nick" style="<%- style %>;cursor:pointer;" data-nick="<%- nick %>"><%- nick %></span>', {
-            nick: word,
-            style: style
+        nickRe = new RegExp('(.*)\\b(' + _kiwi.global.utils.escapeRegex(nick) + ')\\b(.*)', 'i');
+        return word.replace(nickRe, function (__, before, nickInOrigCase, after) {
+            return _.escape(before)
+                + '<span class="inline-nick" style="' + style + '; cursor:pointer" data-nick="' + _.escape(nick) + '">'
+                + _.escape(nickInOrigCase)
+                + '</span>'
+                + _.escape(after);
         });
-
     },
 
 


### PR DESCRIPTION
As it is now, unless a nick is mentioned with no other characters surrounding it (eg: punctuation), it doesn't get highlighted or linked correctly:
![selection_013](https://cloud.githubusercontent.com/assets/426222/5604315/498e7024-93b5-11e4-80a8-78a644911407.png)

This changes that:
![selection_014](https://cloud.githubusercontent.com/assets/426222/5604316/6cdfecf6-93b5-11e4-892d-589549dceb16.png)

It does this by maintaining, alongside the nick cache object, a single regex which matches any nick bordered by word break characters eg: `/\b(tom|dick|harry)\b/`. This means it matches on strings like `tom's` or `hey tom!`. If a user has non word chars (`[^a-z0-9_]`) at the start or end of their username, I this approach won't work, but I dunno... who does that anyway. 