### PR TITLE
Themes can be flagged as 'dark', makes nick highlighting more legible

### DIFF
--- a/client/assets/themes/cli/theme.json
+++ b/client/assets/themes/cli/theme.json
@@ -1,4 +1,5 @@
 {
 	"name": "CLI",
-	"thumbnail_colour": "#222"
+	"thumbnail_colour": "#222",
+	"dark": true
 }

--- a/client/assets/themes/cli/theme.json
+++ b/client/assets/themes/cli/theme.json
@@ -1,5 +1,5 @@
 {
 	"name": "CLI",
 	"thumbnail_colour": "#222",
-	"dark": true
+	"nick_lightness": 60
 }

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -244,16 +244,22 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
 
     // Sgnerate a css style for a nick
     getNickStyles: function(nick) {
-        var ret, colour, nick_int = 0, rgb, isDark;
+        var ret, colour, nick_int = 0, rgb, nick_lightness;
 
         // Get a colour from a nick (Method based on IRSSIs nickcolor.pl)
         _.map(nick.split(''), function (i) { nick_int += i.charCodeAt(0); });
 
-        isDark = (_.find(_kiwi.app.themes, function (theme) {
+        nick_lightness = (_.find(_kiwi.app.themes, function (theme) {
             return theme.name.toLowerCase() === _kiwi.global.settings.get('theme').toLowerCase();
-        }) || {}).dark;
+        }) || {}).nick_lightness;
 
-        rgb = hsl2rgb(nick_int % 255, 70, isDark ? 60 : 35);
+        if (typeof nick_lightness !== 'number') {
+            nick_lightness = 35;
+        } else {
+            nick_lightness = Math.max(0, Math.min(100, nick_lightness));
+        }
+
+        rgb = hsl2rgb(nick_int % 255, 70, nick_lightness);
         rgb = rgb[2] | (rgb[1] << 8) | (rgb[0] << 16);
         colour = '#' + rgb.toString(16);
 

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -244,11 +244,16 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
 
     // Sgnerate a css style for a nick
     getNickStyles: function(nick) {
-        var ret, colour, nick_int = 0, rgb;
+        var ret, colour, nick_int = 0, rgb, isDark;
 
         // Get a colour from a nick (Method based on IRSSIs nickcolor.pl)
         _.map(nick.split(''), function (i) { nick_int += i.charCodeAt(0); });
-        rgb = hsl2rgb(nick_int % 255, 70, 35);
+
+        isDark = (_.find(_kiwi.app.themes, function (theme) {
+            return theme.name.toLowerCase() === _kiwi.global.settings.get('theme').toLowerCase();
+        }) || {}).dark;
+
+        rgb = hsl2rgb(nick_int % 255, 70, isDark ? 60 : 35);
         rgb = rgb[2] | (rgb[1] << 8) | (rgb[0] << 16);
         colour = '#' + rgb.toString(16);
 


### PR DESCRIPTION
Fixes issue #648

Top line is with the fix applied. Bottom line is how it looked before.
![selection_013](https://cloud.githubusercontent.com/assets/426222/5617108/5765c24a-950b-11e4-8b6b-3533439faf93.png)
