### PR TITLE
Added option to toggle display of seconds on timestamps

### DIFF
--- a/client/src/applets/settings.js
+++ b/client/src/applets/settings.js
@@ -16,6 +16,7 @@
                 count_all_activity    : translateText('client_applets_settings_notification_count_all_activity'),
                 timestamps            : translateText('client_applets_settings_timestamp'),
                 timestamp_24          : translateText('client_applets_settings_timestamp_24_hour'),
+                timestamp_seconds     : translateText('client_applets_settings_timestamp_seconds'),
                 mute                  : translateText('client_applets_settings_notification_sound'),
                 emoticons             : translateText('client_applets_settings_emoticons'),
                 scroll_history        : translateText('client_applets_settings_history_length'),

--- a/client/src/index.html.tmpl
+++ b/client/src/index.html.tmpl
@@ -301,6 +301,12 @@
                         </div>
                         <div class="checkbox">
                             <label>
+                                <input data-setting="show_timestamp_seconds" type="checkbox">
+                                <%= timestamp_seconds %>
+                            </label>
+                        </div>
+                        <div class="checkbox">
+                            <label>
                                 <input data-setting="mute_sounds" type="checkbox">
                                 <%= mute %>
                             </label>

--- a/client/src/translations/en-gb.po
+++ b/client/src/translations/en-gb.po
@@ -517,6 +517,10 @@ msgid "client_applets_settings_timestamp_24_hour"
 msgstr "Use 24-hour timestamps"
 
 #: 
+msgid "client_applets_settings_timestamp_seconds"
+msgstr "Show seconds on timestamps"
+
+#: 
 msgid "client_views_panel_timestamp_am"
 msgstr "%s AM"
 

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -353,7 +353,10 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
 
         // Build up and add the line
         if (_kiwi.global.settings.get('use_24_hour_timestamps')) {
-            msg.time_string = msg.time.getHours().toString().lpad(2, "0") + ":" + msg.time.getMinutes().toString().lpad(2, "0") + ":" + msg.time.getSeconds().toString().lpad(2, "0");
+            msg.time_string = msg.time.getHours().toString().lpad(2, "0") + ":" + msg.time.getMinutes().toString().lpad(2, "0");
+            if (_kiwi.global.settings.get('show_timestamp_seconds')) {
+                msg.time_string += ":" + msg.time.getSeconds().toString().lpad(2, "0");
+            }
         } else {
             hour = msg.time.getHours();
             pm = hour > 11;
@@ -366,7 +369,11 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
                 'client_views_panel_timestamp_pm' :
                 'client_views_panel_timestamp_am';
 
-            msg.time_string = translateText(am_pm_locale_key, hour + ":" + msg.time.getMinutes().toString().lpad(2, "0") + ":" + msg.time.getSeconds().toString().lpad(2, "0"));
+            timestr = hour + ":" + msg.time.getMinutes().toString().lpad(2, "0");
+            if (_kiwi.global.settings.get('show_timestamp_seconds')) {
+                timestr += ":" + msg.time.getSeconds().toString().lpad(2, "0");
+            }
+            msg.time_string = translateText(am_pm_locale_key, timestr);
         }
 
         return msg;

--- a/config.example.js
+++ b/config.example.js
@@ -198,6 +198,7 @@ conf.client = {
         show_joins_parts: true,
         show_timestamps: false,
         use_24_hour_timestamps: true,
+        show_timestamp_seconds: true,
         mute_sounds: false,
         show_emoticons: true,
         count_all_activity: false


### PR DESCRIPTION
Added an option to the settings that allows to show/hide the seconds on the timestamps in the channel view.

Example:

24h format
14:45:16   # show seconds
14:45        # don't show seconds

12h format
2:45:16 PM   # show seconds
2:45 PM        # don't show seconds
