### PR TITLE
Update de-de.po

### DIFF
--- a/client/src/translations/de-de.po
+++ b/client/src/translations/de-de.po
@@ -182,7 +182,7 @@ msgstr "hat den Raum betreten"
 
 #: 
 msgid "client_models_channel_quit"
-msgstr "hat %s verlassen"
+msgstr "hat den Raum verlassen %s"
 
 #: 
 msgid "client_models_channel_kicked"


### PR DESCRIPTION
The old translation seemed weird because %s is replaced by the quit message, but the grammar suggests %s is the place that has been left.