### PR TITLE
Change how we invoke server modules.

### DIFF
--- a/server/modules.js
+++ b/server/modules.js
@@ -56,7 +56,7 @@ function loadModule (module_file) {
         return false;
     }
 
-    return module(__dirname);
+    return module(Module, __dirname);
 }
 
 

--- a/server/modules.js
+++ b/server/modules.js
@@ -56,7 +56,7 @@ function loadModule (module_file) {
         return false;
     }
 
-    return module;
+    return module(__dirname);
 }
 
 

--- a/server_modules/control.js
+++ b/server_modules/control.js
@@ -10,11 +10,10 @@ var net                = require('net'),
     winston            = require('winston'),
     ControlInterface;
 
-function initModule(server_dir) {
-    var kiwiModules = require(path.join(server_dir, 'modules.js'));
-        control_module = new kiwiModules.Module('Control');
+function initModule(KiwiModule, server_dir) {
+    var control_module = new KiwiModule('Control');
 
-    ControlInterface = require(path.join(server_dir, 'controlinterface.js')),
+    ControlInterface = require(path.join(server_dir, 'controlinterface.js'));
 
     /**
      * Start the control socket server to serve connections

--- a/server_modules/control.js
+++ b/server_modules/control.js
@@ -5,12 +5,31 @@
  */
 
 var net                = require('net'),
-    kiwiModules        = require('../server/modules'),
-    ControlInterface   = require('../server/controlinterface.js'),
+    path               = require('path'),
     _                  = require('lodash'),
-    winston            = require('winston');
+    winston            = require('winston'),
+    ControlInterface;
 
-var control_module = new kiwiModules.Module('Control');
+function initModule(server_dir) {
+    var kiwiModules = require(path.join(server_dir, 'modules.js'));
+        control_module = new kiwiModules.Module('Control');
+
+    ControlInterface = require(path.join(server_dir, 'controlinterface.js')),
+
+    /**
+     * Start the control socket server to serve connections
+     */
+    var server = net.createServer(function (socket) {
+        new SocketClient(socket);
+    });
+    server.listen(8888);
+
+    control_module.on('dispose', function() {
+        server.close();
+    });
+}
+
+module.exports = initModule;
 
 
 /**
@@ -73,16 +92,3 @@ var socket_commands = {
         this.socket_closing = true;
     }
 };
-
-
-/**
- * Start the control socket server to serve connections
- */
-var server = net.createServer(function (socket) {
-    new SocketClient(socket);
-});
-server.listen(8888);
-
-control_module.on('dispose', function() {
-    server.close();
-});

--- a/server_modules/dnsbl.js
+++ b/server_modules/dnsbl.js
@@ -5,8 +5,7 @@
  */
 
 var dns = require('dns'),
-    kiwiModules = require('../server/modules');
-
+    path = require('path');
 
 // The available DNS zones to check against
 var bl_zones = {
@@ -16,30 +15,32 @@ var bl_zones = {
 // The DNS zone we should use
 var current_bl = 'dronebl';
 
+function initModule(server_dir) {
+    var kiwiModules = require(path.join(server_dir, 'modules.js')),
+    dnsbl_module = new kiwiModules.Module('DNSBL');
 
-var module = new kiwiModules.Module('DNSBL');
+    dnsbl_module.on('irc connecting', function (event, event_data) {
+        var client_addr = event_data.connection.state.client.websocket.meta.real_address;
 
-module.on('irc connecting', function (event, event_data) {
-    event.wait = true;
+        event.wait = true;
 
-    var client_addr = event_data.connection.state.client.websocket.meta.real_address;
+        isBlacklisted(client_addr, function(is_blocked) {
+            if (is_blocked) {
+                var err = new Error('DNSBL blocked (' + client_addr + ')');
+                err.code = 'Blacklisted';
 
-    isBlacklisted(client_addr, function(is_blocked) {
-        if (is_blocked) {
-            var err = new Error('DNSBL blocked (' + client_addr + ')');
-            err.code = 'Blacklisted';
+                event_data.connection.emit('error', err);
+                event.preventDefault();
+                event.callback();
 
-            event_data.connection.emit('error', err);
-            event.preventDefault();
-            event.callback();
-
-        } else {
-            event.callback();
-        }
+            } else {
+                event.callback();
+            }
+        });
     });
-});
+}
 
-
+module.exports = initModule;
 
 // The actual checking against the DNS blacklist
 function isBlacklisted(ip, callback) {

--- a/server_modules/dnsbl.js
+++ b/server_modules/dnsbl.js
@@ -15,9 +15,8 @@ var bl_zones = {
 // The DNS zone we should use
 var current_bl = 'dronebl';
 
-function initModule(server_dir) {
-    var kiwiModules = require(path.join(server_dir, 'modules.js')),
-    dnsbl_module = new kiwiModules.Module('DNSBL');
+function initModule(KiwiModule) {
+    var dnsbl_module = new KiwiModule('DNSBL');
 
     dnsbl_module.on('irc connecting', function (event, event_data) {
         var client_addr = event_data.connection.state.client.websocket.meta.real_address;

--- a/server_modules/example.js
+++ b/server_modules/example.js
@@ -1,8 +1,7 @@
 var path = require('path');
 
-function initModule(server_dir) {
-    var kiwiModules = require(path.join(server_dir, 'modules.js')),
-        example_module = new kiwiModules.Module('Example Module');
+function initModule(KiwiModule) {
+    var example_module = new KiwiModule('Example Module');
 
     // A web client is connected
     example_module.on('client created', function(event, data) {

--- a/server_modules/example.js
+++ b/server_modules/example.js
@@ -1,35 +1,39 @@
-var kiwiModules = require('../server/modules');
+var path = require('path');
 
-var module = new kiwiModules.Module('Example Module');
+function initModule(server_dir) {
+    var kiwiModules = require(path.join(server_dir, 'modules.js')),
+        example_module = new kiwiModules.Module('Example Module');
 
-
-// A web client is connected
-module.on('client created', function(event, data) {
-    console.log('[client connection]', data);
-});
-
-
-// The Client recieves a IRC PRIVMSG command
-module.on('irc message', function(event, data) {
-	console.log('[MESSAGE]', data.irc_event);
-});
-
-// The Client recieves a IRC USER NOTICE command
-module.on('irc user notice', function(event, data) {
-	console.log('[NOTICE]', data.irc_event);
-});
-
-// The client recieves an IRC JOIN command
-module.on('irc channel join', function(event, data) {
-	console.log('[JOIN]', data.irc_event);
-});
+    // A web client is connected
+    example_module.on('client created', function(event, data) {
+        console.log('[client connection]', data);
+    });
 
 
-// A command has been sent from the client
-module.on('client command', function(event, data) {
-	var client_method = data.command.method;
-	var client_args = data.command.args;
+    // The Client recieves a IRC PRIVMSG command
+    example_module.on('irc message', function(event, data) {
+        console.log('[MESSAGE]', data.irc_event);
+    });
 
-	console.log('[CLIENT COMMAND]', client_method);
-	console.log('    ', client_args);
-});
+    // The Client recieves a IRC USER NOTICE command
+    example_module.on('irc user notice', function(event, data) {
+        console.log('[NOTICE]', data.irc_event);
+    });
+
+    // The client recieves an IRC JOIN command
+    example_module.on('irc channel join', function(event, data) {
+        console.log('[JOIN]', data.irc_event);
+    });
+
+
+    // A command has been sent from the client
+    example_module.on('client command', function(event, data) {
+        var client_method = data.command.method;
+        var client_args = data.command.args;
+
+        console.log('[CLIENT COMMAND]', client_method);
+        console.log('    ', client_args);
+    });
+}
+
+module.exports = initModule;

--- a/server_modules/proxychecker.js
+++ b/server_modules/proxychecker.js
@@ -8,9 +8,8 @@ var util = require('util'),
     path = require('path'),
     net  = require('net');
 
-function initModule(server_dir) {
-    var kiwiModules = require(path.join(server_dir, 'modules.js')),
-        proxychecker_module = new kiwiModules.Module('proxychecker'),
+function initModule(KiwiModule) {
+    var proxychecker_module = new KiwiModule('proxychecker'),
         client_addr = event_data.connection.state.client.websocket.meta.real_address;
 
     event.wait = true;

--- a/server_modules/proxychecker.js
+++ b/server_modules/proxychecker.js
@@ -5,36 +5,37 @@
  */
 
 var util = require('util'),
-    kiwiModules = require('../server/modules');
+    path = require('path'),
+    net  = require('net');
 
+function initModule(server_dir) {
+    var kiwiModules = require(path.join(server_dir, 'modules.js')),
+        proxychecker_module = new kiwiModules.Module('proxychecker'),
+        client_addr = event_data.connection.state.client.websocket.meta.real_address;
 
-var module = new kiwiModules.Module('proxychecker');
-
-module.on('irc connecting', function (event, event_data) {
     event.wait = true;
 
-    var client_addr = event_data.connection.state.client.websocket.meta.real_address;
+    proxychecker_module.on('irc connecting', function (event, event_data) {
+        checkForOpenProxies(client_addr, function(is_proxy, host, port) {
+            var err;
+            if (is_proxy) {
+                err = new Error(util.format('Proxy detected on %s:%d', client_addr, port));
+                err.code = 'Blocked proxy';
 
-    checkForOpenProxies(client_addr, function(is_proxy, host, port) {
-        if (is_proxy) {
-            var err = new Error(util.format('Proxy detected on %s:%d', client_addr, port));
-            err.code = 'Blocked proxy';
+                event_data.connection.emit('error', err);
+                event.preventDefault();
+                event.callback();
 
-            event_data.connection.emit('error', err);
-            event.preventDefault();
-            event.callback();
-
-        } else {
-            event.callback();
-        }
+            } else {
+                event.callback();
+            }
+        });
     });
-});
+}
 
-
+module.exports = initModule;
 
 function checkForOpenProxies(host, callback) {
-    var net = require('net');
-
     var ports = [80,8080,81,1080,6588,8000];
     var ports_completed = 0;
 

--- a/server_modules/stats.js
+++ b/server_modules/stats.js
@@ -4,27 +4,28 @@
  * Retreive stats for internal kiwi events. Handy for graphing
  */
 
-var kiwiModules = require('../server/modules'),
-    fs = require('fs');
+var fs = require('fs');
 
+function initModule(server_dir) {
+    var kiwiModules = require(path.join(server_dir, 'modules.js'));,
+        stats_module = new kiwiModules.Module('stats_file'),
+        stats_file = fs.createWriteStream('kiwi_stats.log', {'flags': 'a'});
 
+    stats_module.on('stat counter', function (event, event_data) {
+        var stat_name = event_data.name,
+            timestamp,
+            ignored_events = [];
 
-var module = new kiwiModules.Module('stats_file');
+        // Some events may want to be ignored
+        ignored_events.push('http.request');
 
-var stats_file = fs.createWriteStream('kiwi_stats.log', {'flags': 'a'});
+        if (ignored_events.indexOf(stat_name) > -1) {
+            return;
+        }
 
-module.on('stat counter', function (event, event_data) {
-    var stat_name = event_data.name,
-        timestamp,
-        ignored_events = [];
+        timestamp = Math.floor((new Date()).getTime() / 1000);
+        stats_file.write(timestamp.toString() + ' ' + stat_name + '\n');
+    });
+}
 
-    // Some events may want to be ignored
-    ignored_events.push('http.request');
-
-    if (ignored_events.indexOf(stat_name) > -1) {
-        return;
-    }
-
-    timestamp = Math.floor((new Date()).getTime() / 1000);
-    stats_file.write(timestamp.toString() + ' ' + stat_name + '\n');
-});
+module.exports = initModule;

--- a/server_modules/stats.js
+++ b/server_modules/stats.js
@@ -6,9 +6,8 @@
 
 var fs = require('fs');
 
-function initModule(server_dir) {
-    var kiwiModules = require(path.join(server_dir, 'modules.js'));,
-        stats_module = new kiwiModules.Module('stats_file'),
+function initModule(KiwiModule) {
+    var stats_module = new KiwiModule('stats_file'),
         stats_file = fs.createWriteStream('kiwi_stats.log', {'flags': 'a'});
 
     stats_module.on('stat counter', function (event, event_data) {

--- a/server_modules/web_agent_debugger.js
+++ b/server_modules/web_agent_debugger.js
@@ -7,10 +7,9 @@
 
 var path = require('path');
 
-function initModule(server_dir) {
-    var kiwiModules = require(path.join(server_dir, 'modules.js')),
-        agent = require('webkit-devtools-agent'),
-        debugger_module = new kiwiModules.Module('web_agent_debugger');
+function initModule(KiwiModule, server_dir) {
+    var agent = require('webkit-devtools-agent'),
+        debugger_module = new KiwiModule('web_agent_debugger');
 
     agent.start({
         port: 9999,

--- a/server_modules/web_agent_debugger.js
+++ b/server_modules/web_agent_debugger.js
@@ -5,22 +5,25 @@
  * Requires npm module: webkit-devtools-agent
  */
 
+var path = require('path');
 
-var kiwiModules = require('../server/modules'),
-	agent = require('webkit-devtools-agent');
+function initModule(server_dir) {
+    var kiwiModules = require(path.join(server_dir, 'modules.js')),
+        agent = require('webkit-devtools-agent'),
+        debugger_module = new kiwiModules.Module('web_agent_debugger');
 
-
-var module = new kiwiModules.Module('web_agent_debugger');
-
-agent.start({
+    agent.start({
         port: 9999,
         bind_to: '0.0.0.0',
         ipc_port: 3333,
         verbose: true
     });
 
-console.log('Debugging can be accessed via http://c4milo.github.io/node-webkit-agent/26.0.1410.65/inspector.html?host=localhost:9999&page=0');
+    console.log('Debugging can be accessed via http://c4milo.github.io/node-webkit-agent/26.0.1410.65/inspector.html?host=localhost:9999&page=0');
 
-module.on('dispose', function() {
-	agent.stop();
-});
+    module.on('dispose', function() {
+        agent.stop();
+    });
+}
+
+module.exports = initModule;


### PR DESCRIPTION
Modules should now export a factory method that is called with the path to the server directory instead of just `require()`ing a hard-coded path to the Module module.

This is a breaking change for server modules.