### PR TITLE
Add support for wildcard/hostmask ignores.

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -33,7 +33,7 @@ _kiwi.global = {
         this.utils.formatIRCMsg = formatIRCMsg;
         this.utils.styleText = styleText;
         this.utils.hsl2rgb = hsl2rgb;
-        this.utils.normaliseIgnore = normaliseIgnore;
+        this.utils.toUserMask = toUserMask;
 
         this.utils.notifications = _kiwi.utils.notifications;
         this.utils.formatDate = _kiwi.utils.formatDate;

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -33,6 +33,7 @@ _kiwi.global = {
         this.utils.formatIRCMsg = formatIRCMsg;
         this.utils.styleText = styleText;
         this.utils.hsl2rgb = hsl2rgb;
+        this.utils.normaliseIgnore = normaliseIgnore;
 
         this.utils.notifications = _kiwi.utils.notifications;
         this.utils.formatDate = _kiwi.utils.formatDate;

--- a/client/src/helpers/utils.js
+++ b/client/src/helpers/utils.js
@@ -594,16 +594,16 @@ function styleText(string_id, params) {
 *   @param      {String}    host The user mask to format.
 *   @returns    {Array}          An array with the full user mask and regex.
 */
-function normaliseIgnore (inp, noArray) {
-         // Convert input to full user masks.
-         var tmp = inp.match(/([^!@]+)!?([^!@]+)?@?(.+)?/),
-             res = (tmp[1]||'*') + '!' + (tmp[2]||'*') + '@' + (tmp[3]||'*');
+function toUserMask (inp, no_array) {
+    // Convert input to full user masks.
+    var tmp = inp.match(/([^!@]+)!?([^!@]+)?@?(.+)?/),
+        res = (tmp[1]||'*') + '!' + (tmp[2]||'*') + '@' + (tmp[3]||'*');
 
-         // Return the full user mask only if noArray is true.
-         if (noArray) {
-            return res;
-          } else {
-            // Return an array with the full user mask and RegEx.
-            return [res, new RegExp('^'+res.toLowerCase().replace(/\./g,'\\.').replace(/\*/g,'(.[^!@]*?)')+'$','i')];
-         }
+    // Return the generated user mask only if no_array is true.
+    if (no_array) {
+       return res;
+    } else {
+       // Return an array with the full user mask and RegEx.
+       return [res, new RegExp('^'+res.toLowerCase().replace(/\./g,'\\.').replace(/\*/g,'(.[^!@]*?)')+'$','i')];
+    }
 }

--- a/client/src/helpers/utils.js
+++ b/client/src/helpers/utils.js
@@ -587,3 +587,23 @@ function styleText(string_id, params) {
 
     return text;
 }
+
+
+/*
+* Convert input to valid ignore regex.
+*   @param      {String}    host The user mask to format.
+*   @returns    {Array}          An array with the full user mask and regex.
+*/
+function normaliseIgnore (inp, noArray) {
+         // Convert input to full user masks.
+         var tmp = inp.match(/([^!@]+)!?([^!@]+)?@?(.+)?/),
+             res = (tmp[1]||'*') + '!' + (tmp[2]||'*') + '@' + (tmp[3]||'*');
+
+         // Return the full user mask only if noArray is true.
+         if (noArray) {
+            return res;
+          } else {
+            // Return an array with the full user mask and RegEx.
+            return [res, new RegExp('^'+res.toLowerCase().replace(/\./g,'\\.').replace(/\*/g,'(.[^!@]*?)')+'$','i')];
+         }
+}

--- a/client/src/misc/clientuicommands.js
+++ b/client/src/misc/clientuicommands.js
@@ -212,7 +212,7 @@
                 if (list.length > 0) {
                     this.app.panels().active.addMsg(' ', styleText('ignore_title', {text: translateText('client_models_application_ignore_title')}));
                     $.each(list, function (idx, ignored_pattern) {
-                        that.app.panels().active.addMsg(' ', styleText('ignored_pattern', {text: ignored_pattern}));
+                        that.app.panels().active.addMsg(' ', styleText('ignored_pattern', {text: ignored_pattern[0]}));
                     });
                 } else {
                     this.app.panels().active.addMsg(' ', styleText('ignore_none', {text: translateText('client_models_application_ignore_none')}));
@@ -220,10 +220,11 @@
                 return;
             }
 
-            // We have a parameter, so add it
-            list.push(ev.params[0]);
+            // We have a parameter, so add it, first convert it to regex.
+            var normalised = normaliseIgnore(ev.params[0]);
+            list.push(normalised);
             this.app.connections.active_connection.set('ignore_list', list);
-            this.app.panels().active.addMsg(' ', styleText('ignore_nick', {text: translateText('client_models_application_ignore_nick', [ev.params[0]])}));
+            this.app.panels().active.addMsg(' ', styleText('ignore_nick', {text: translateText('client_models_application_ignore_nick', [normalised[0]])}));
         }
     };
 
@@ -238,13 +239,14 @@
                 return;
             }
 
+            var normalised = normaliseIgnore(ev.params[0]);
             list = _.reject(list, function(pattern) {
-                return pattern === ev.params[0];
+                return pattern[1].toString() === normalised[1].toString();
             });
 
             this.app.connections.active_connection.set('ignore_list', list);
 
-            this.app.panels().active.addMsg(' ', styleText('ignore_stopped', {text: translateText('client_models_application_ignore_stopped', [ev.params[0]])}));
+            this.app.panels().active.addMsg(' ', styleText('ignore_stopped', {text: translateText('client_models_application_ignore_stopped', [normalised[0]])}));
         }
     };
 

--- a/client/src/misc/clientuicommands.js
+++ b/client/src/misc/clientuicommands.js
@@ -221,10 +221,10 @@
             }
 
             // We have a parameter, so add it, first convert it to regex.
-            var normalised = normaliseIgnore(ev.params[0]);
-            list.push(normalised);
+            var user_mask = toUserMask(ev.params[0]);
+            list.push(user_mask);
             this.app.connections.active_connection.set('ignore_list', list);
-            this.app.panels().active.addMsg(' ', styleText('ignore_nick', {text: translateText('client_models_application_ignore_nick', [normalised[0]])}));
+            this.app.panels().active.addMsg(' ', styleText('ignore_nick', {text: translateText('client_models_application_ignore_nick', [user_mask[0]])}));
         }
     };
 
@@ -239,14 +239,14 @@
                 return;
             }
 
-            var normalised = normaliseIgnore(ev.params[0]);
+            var user_mask = toUserMask(ev.params[0]);
             list = _.reject(list, function(pattern) {
-                return pattern[1].toString() === normalised[1].toString();
+                return pattern[1].toString() === user_mask[1].toString();
             });
 
             this.app.connections.active_connection.set('ignore_list', list);
 
-            this.app.panels().active.addMsg(' ', styleText('ignore_stopped', {text: translateText('client_models_application_ignore_stopped', [normalised[0]])}));
+            this.app.panels().active.addMsg(' ', styleText('ignore_stopped', {text: translateText('client_models_application_ignore_stopped', [user_mask[0]])}));
         }
     };
 

--- a/client/src/models/network.js
+++ b/client/src/models/network.js
@@ -223,18 +223,19 @@
             return (channel_prefix.indexOf(channel_name[0]) > -1);
         },
 
-        // Check a nick alongside our ignore list
-        isNickIgnored: function (nick) {
+        // Check if a user is ignored.
+        // Accepts an object with nick, ident and hostname OR a string.
+        isUserIgnored: function (mask) {
             var idx, list = this.get('ignore_list');
-            var pattern, regex;
+
+            if (typeof mask === "object") {
+               mask = (mask.nick||'*')+'!'+(mask.ident||'*')+'@'+(mask.hostname||'*');
+            }
 
             for (idx = 0; idx < list.length; idx++) {
-                pattern = list[idx].replace(/([.+^$[\]\\(){}|-])/g, "\\$1")
-                    .replace('*', '.*')
-                    .replace('?', '.');
-
-                regex = new RegExp(pattern, 'i');
-                if (regex.test(nick)) return true;
+                if (list[idx][1].test(mask)) {
+                   return true;
+                }
             }
 
             return false;
@@ -460,7 +461,7 @@
                 is_pm = ((event.target || '').toLowerCase() == this.get('nick').toLowerCase());
 
             // An ignored user? don't do anything with it
-            if (this.isNickIgnored(event.nick)) {
+            if (this.isUserIgnored(event)) {
                 return;
             }
 
@@ -551,7 +552,7 @@
 
     function onCtcpRequest(event) {
         // An ignored user? don't do anything with it
-        if (this.isNickIgnored(event.nick)) {
+        if (this.isUserIgnored(event)) {
             return;
         }
 
@@ -567,7 +568,7 @@
 
     function onCtcpResponse(event) {
         // An ignored user? don't do anything with it
-        if (this.isNickIgnored(event.nick)) {
+        if (this.isUserIgnored(event)) {
             return;
         }
 

--- a/client/src/models/network.js
+++ b/client/src/models/network.js
@@ -230,6 +230,8 @@
 
             if (typeof mask === "object") {
                mask = (mask.nick||'*')+'!'+(mask.ident||'*')+'@'+(mask.hostname||'*');
+            } else if (typeof mask === "string") {
+               mask = toUserMask(mask, true);
             }
 
             for (idx = 0; idx < list.length; idx++) {

--- a/client/src/views/userbox.js
+++ b/client/src/views/userbox.js
@@ -31,7 +31,7 @@ _kiwi.view.UserBox = Backbone.View.extend({
         this.user = user;
         this.channel = channel;
 
-        var is_ignored = _kiwi.app.connections.active_connection.isUserIgnored(normaliseIgnore(this.user.get('nick'), true));
+        var is_ignored = _kiwi.app.connections.active_connection.isUserIgnored(toUserMask(this.user.get('nick'), true));
         this.$('.ignore input').attr('checked', is_ignored ? 'checked' : false);
     },
 

--- a/client/src/views/userbox.js
+++ b/client/src/views/userbox.js
@@ -31,7 +31,7 @@ _kiwi.view.UserBox = Backbone.View.extend({
         this.user = user;
         this.channel = channel;
 
-        var is_ignored = _kiwi.app.connections.active_connection.isNickIgnored(this.user.get('nick'));
+        var is_ignored = _kiwi.app.connections.active_connection.isUserIgnored(normaliseIgnore(this.user.get('nick'), true));
         this.$('.ignore input').attr('checked', is_ignored ? 'checked' : false);
     },
 


### PR DESCRIPTION
Allow users to use '*' as a wildcard when issuing ignores as well as hostmask ignores.

Examples:
/ignore LouisT
/ignore LouisT!*@sub.domain.*
/ignore LouisT*!ident@*.domain.*
/Ignore LouisT!ident@sub.domain.tld