### PR TITLE
Add missing german translation for custom highlights option

### DIFF
--- a/client/src/translations/de-de.po
+++ b/client/src/translations/de-de.po
@@ -716,3 +716,6 @@ msgstr "Nachricht senden..."
 msgid "disconnect_from_server"
 msgstr "This will disconnect from the IRC network. Are you sure?"
 
+#: 
+msgid "client_applets_settings_custom_highlights"
+msgstr "Highlights (getrennt durch Leerzeichen)"


### PR DESCRIPTION
Without this fix the text `client_applets_settings_custom_highlights` is displayed in the settings.