### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.2-dev",
   "description": "A hand-crafted webirc client",
   "homepage": "https://www.kiwiirc.com/",
+  "license": "AGPL-3.0",
   "preferGlobal": "true",
   "bin": {
     "kiwiirc": "./kiwi"


### PR DESCRIPTION
As of [version 2.10.0](https://github.com/npm/npm/blob/master/CHANGELOG.md#v2100-2015-05-8) npm will emit a warning when the `license` field is missing from package.json.