### PR TITLE
Added HTTP to HTTPS redirect for servers using SSL

### DIFF
--- a/server/weblistener.js
+++ b/server/weblistener.js
@@ -8,7 +8,7 @@ var engine       = require('engine.io'),
     dns          = require('dns'),
     url          = require('url'),
     _            = require('lodash'),
-    spdy         = require('spdy'),
+    spdy         = require('https'),
     ipaddr       = require('ipaddr.js'),
     winston      = require('winston'),
     Client       = require('./client.js').Client,
@@ -58,6 +58,15 @@ var WebListener = module.exports = function (web_config) {
 
         hs.listen(web_config.port, web_config.address, function () {
             that.emit('listening');
+            
+            //Redirect from http port to https
+            if (web_config.http_redirect) {
+                var http = require('http');
+                http.createServer(function (req, res) {
+                    res.writeHead(301, { "Location": "https://" + req.headers['host'] + req.url });
+                    res.end();
+                }).listen(web_config.http_redirect_port);
+            }
         });
     } else {
 


### PR DESCRIPTION
This change allows the server to redirect all http traffic on a specified port to the port used for SSL connections.  To enable this option you will need to add two extra options to the server block for SSL servers in config.js, the following example details the options (using standard https and http ports for clarity but not required):

conf.servers.push({
    port:     "443",
    address: "0.0.0.0",
    ssl:   true,
    ssl_key: "example.key",
    ssl_ca: "example.ca",
    ssl_cert: "example.crt",
    // HTTP redirect options
    http_redirect: true,
    http_redirect_port: "80"
});


(Also updated the spdy require to use https instead of spdy to help deal with web browsers not liking spdy)