### PR TITLE
Add support for unicode characters in URLs

### DIFF
--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -223,7 +223,7 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
         var found_a_url = false,
             parsed_url;
 
-        parsed_url = word.replace(/^(([A-Za-z][A-Za-z0-9\-]*\:\/\/)|(www\.))([\w.\-]+)([a-zA-Z]{2,6})(:[0-9]+)?(\/[\w!:.?$'()[\]*,;~+=&%@!\-\/]*)?(#.*)?$/gi, function (url) {
+        parsed_url = word.replace(/^(([A-Za-z][A-Za-z0-9\-]*\:\/\/)|(www\.))([\w\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF.\-]+)([a-zA-Z]{2,6})(:[0-9]+)?(\/[\w\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF!:.?$'()[\]*,;~+=&%@!\-\/]*)?(#.*)?$/gi, function (url) {
             var nice = url,
                 extra_html = '';
 


### PR DESCRIPTION
I added handling for unicode characters in URL regexp, so links like `http://śćółź-żć.śąę.pl/śćó.łźżćśąę?śćółź=żćśąę#śćółźżćśąę` are also clickable.

Solution based on this answer: http://stackoverflow.com/a/1073545