### PR TITLE
Exit with status 1 in case `kiwi check` returns a non-running app

### DIFF
--- a/kiwi_check
+++ b/kiwi_check
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+kiwi_dir=$(cd `dirname $0`; pwd)
+
+cd ${kiwi_dir}
+if [ -x ${kiwi_dir}/kiwi ] ; then
+    ./kiwi status >/dev/null 2>&1
+    rc=$?
+
+    if [ ${rc} -eq 1 ] ; then
+        ./kiwi start
+        exit $?
+    else
+        exit 0
+    fi
+fi

--- a/server/helpers/launcher.js
+++ b/server/helpers/launcher.js
@@ -48,11 +48,12 @@ switch (process.argv[2]) {
 
     case 'status':
         var pid = daemon.status();
-        if (pid)
+        if (pid) {
             console.log('Daemon running. PID: ' + pid);
-        else
+        } else {
             console.log('Daemon is not running.');
             process.exit(1);
+        }
         break;
 
     case 'reconfig':

--- a/server/helpers/launcher.js
+++ b/server/helpers/launcher.js
@@ -52,6 +52,7 @@ switch (process.argv[2]) {
             console.log('Daemon running. PID: ' + pid);
         else
             console.log('Daemon is not running.');
+            process.exit(1);
         break;
 
     case 'reconfig':


### PR DESCRIPTION
This can be used for a cron-based check to determine more easily if KiwiIRC is still running or needs to be (re-)started in case nodejs crashed (which recently happened to me).