### PR TITLE
Quoted node command to avoid issues with 'Program Files' etc.

### DIFF
--- a/client/src/applets/settings.js
+++ b/client/src/applets/settings.js
@@ -37,6 +37,7 @@
                 enable_notifications  : translateText('client_applets_settings_enable_notifications'),
                 custom_highlights     : translateText('client_applets_settings_custom_highlights'),
                 autocomplete_slideout : translateText('client_applets_settings_autocomplete_slideout'),
+                lastspoke_ordering    : translateText('client_applets_settings_lastspoke_ordering'),
                 theme_thumbnails: _.map(_kiwi.app.themes, function (theme) {
                     return _.template($('#tmpl_theme_thumbnail').html().trim())(theme);
                 })

--- a/client/src/applets/settings.js
+++ b/client/src/applets/settings.js
@@ -37,7 +37,7 @@
                 enable_notifications  : translateText('client_applets_settings_enable_notifications'),
                 custom_highlights     : translateText('client_applets_settings_custom_highlights'),
                 autocomplete_slideout : translateText('client_applets_settings_autocomplete_slideout'),
-                lastspoke_ordering    : translateText('client_applets_settings_lastspoke_ordering'),
+                last_spoke_ordering   : translateText('client_applets_settings_last_spoke_ordering'),
                 theme_thumbnails: _.map(_kiwi.app.themes, function (theme) {
                     return _.template($('#tmpl_theme_thumbnail').html().trim())(theme);
                 })

--- a/client/src/index.html.tmpl
+++ b/client/src/index.html.tmpl
@@ -290,6 +290,12 @@
                                 <%= autocomplete_slideout %>
                             </label>
                         </div>
+                        <div class="checkbox">
+                            <label>
+                                <input data-setting="use_lastspoke_ordering" type="checkbox">
+                                <%= lastspoke_ordering %>
+                            </label>
+                        </div>
                         <div>
                             <label>
                                 <input data-setting="scrollback" class="input-small" type="text" size="4" pattern="\d*">
@@ -584,7 +590,7 @@
                     $.each(opts.themes, function (theme_idx, theme) {
                         var disabled = (opts.server_settings.client.settings.theme.toLowerCase() !== theme.name.toLowerCase());
                         var link = $.parseHTML('<link rel="stylesheet" type="text/css" data-theme href="'+ opts.base_path + '/assets/themes/' + theme.name.toLowerCase() + '/style.css" title="' + theme.name.toLowerCase() + '" />');
-                        
+
                         $(link).appendTo($('head'));
                         if (disabled) {
                             link.disabled = disabled;

--- a/client/src/index.html.tmpl
+++ b/client/src/index.html.tmpl
@@ -292,8 +292,8 @@
                         </div>
                         <div class="checkbox">
                             <label>
-                                <input data-setting="use_lastspoke_ordering" type="checkbox">
-                                <%= lastspoke_ordering %>
+                                <input data-setting="use_last_spoke_ordering" type="checkbox">
+                                <%= last_spoke_ordering %>
                             </label>
                         </div>
                         <div>

--- a/client/src/models/member.js
+++ b/client/src/models/member.js
@@ -10,7 +10,7 @@ _kiwi.model.Member = Backbone.Model.extend({
         modes = modes || [];
         this.sortModes(modes);
 
-        this.set({"nick": nick, "modes": modes, "prefix": this.getPrefix(modes)}, {silent: true});
+        this.set({"nick": nick, "modes": modes, "prefix": this.getPrefix(modes), "lastSpoke": -1}, {silent: true});
 
         this.updateOpStatus();
 

--- a/client/src/models/member.js
+++ b/client/src/models/member.js
@@ -10,7 +10,7 @@ _kiwi.model.Member = Backbone.Model.extend({
         modes = modes || [];
         this.sortModes(modes);
 
-        this.set({"nick": nick, "modes": modes, "prefix": this.getPrefix(modes), "lastSpoke": -1}, {silent: true});
+        this.set({"nick": nick, "modes": modes, "prefix": this.getPrefix(modes), "last_spoke": -1}, {silent: true});
 
         this.updateOpStatus();
 

--- a/client/src/translations/en-gb.po
+++ b/client/src/translations/en-gb.po
@@ -872,3 +872,6 @@ msgstr "Stop ignoring somebody"
 msgid "client_applets_settings_autocomplete_slideout"
 msgstr "Show the autocomplete box"
 
+#: 
+msgid "client_applets_settings_lastspoke_ordering"
+msgstr "Use 'last spoke' ordering for autocompletion"

--- a/client/src/translations/en-gb.po
+++ b/client/src/translations/en-gb.po
@@ -873,5 +873,5 @@ msgid "client_applets_settings_autocomplete_slideout"
 msgstr "Show the autocomplete box"
 
 #: 
-msgid "client_applets_settings_lastspoke_ordering"
+msgid "client_applets_settings_last_spoke_ordering"
 msgstr "Use 'last spoke' ordering for autocompletion"

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -368,8 +368,8 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
         if (msg.nick) {
             // we're in a channel and this nick is, too
             if (this.model.get("members") && this.model.get("members").getByNick(msg.nick)) {
-              // set last_spoke time
-              this.model.get("members").getByNick(msg.nick).set("last_spoke", msg.time.getTime());
+                // set last_spoke time
+                this.model.get("members").getByNick(msg.nick).set("last_spoke", msg.time.getTime());
             }
 
             _.map(msg.nick.split(''), function (char) {

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -366,6 +366,12 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
         // Generate a hex string from the nick to be used as a CSS class name
         nick_hex = '';
         if (msg.nick) {
+            // we're in a channel and this nick is, too
+            if (this.model.get("members") && this.model.get("members").getByNick(msg.nick)) {
+              // set lastSpoke time
+              this.model.get("members").getByNick(msg.nick).set("lastSpoke",msg.time.getTime());
+            }
+
             _.map(msg.nick.split(''), function (char) {
                 nick_hex += char.charCodeAt(0).toString(16);
             });

--- a/client/src/views/channel.js
+++ b/client/src/views/channel.js
@@ -368,8 +368,8 @@ _kiwi.view.Channel = _kiwi.view.Panel.extend({
         if (msg.nick) {
             // we're in a channel and this nick is, too
             if (this.model.get("members") && this.model.get("members").getByNick(msg.nick)) {
-              // set lastSpoke time
-              this.model.get("members").getByNick(msg.nick).set("lastSpoke",msg.time.getTime());
+              // set last_spoke time
+              this.model.get("members").getByNick(msg.nick).set("last_spoke", msg.time.getTime());
             }
 
             _.map(msg.nick.split(''), function (char) {

--- a/client/src/views/controlbox.js
+++ b/client/src/views/controlbox.js
@@ -331,10 +331,17 @@ _kiwi.view.ControlBox = Backbone.View.extend({
 
             // Sort what we have alphabetically
             autocomplete_list = _.sortBy(autocomplete_list, function (entry) {
-                // Nicks have a .type property of 'nick'
-                return entry.type === 'nick' ?
-                    entry.match[0].toLowerCase() :
-                    entry.toLowerCase();
+                  if (entry.type === 'nick' ) {
+                    if ( _kiwi.global.settings.get('use_lastspoke_ordering') ) {
+                      lastSpoke = _kiwi.app.panels().active.get('members').getByNick(entry.match[0]).get("lastSpoke");
+                      // sort first by lastspoke in reverse order, then by nick
+                      return [-lastSpoke, entry.match[0].toLowerCase()].join("_");
+                    } else {
+                      return entry.match[0].toLowerCase();
+                    }
+                  } else {
+                    return entry.toLowerCase();
+                  }
             });
 
             this.showAutocomplete(autocomplete_list, 'nicks');

--- a/client/src/views/controlbox.js
+++ b/client/src/views/controlbox.js
@@ -208,7 +208,7 @@ _kiwi.view.ControlBox = Backbone.View.extend({
         var that = this,
             inp = $(ev.currentTarget),
             inp_val = inp.val(),
-            meta;
+            meta, last_spoke;
 
         if (navigator.appVersion.indexOf("Mac") !== -1) {
             meta = ev.metaKey;
@@ -329,20 +329,20 @@ _kiwi.view.ControlBox = Backbone.View.extend({
             // Add this channels name into the auto complete list
             autocomplete_list.push(_kiwi.app.panels().active.get('name'));
 
-            // Sort what we have alphabetically
-            autocomplete_list = _.sortBy(autocomplete_list, function (entry) {
-                  if (entry.type === 'nick' ) {
-                    if ( _kiwi.global.settings.get('use_lastspoke_ordering') ) {
-                      lastSpoke = _kiwi.app.panels().active.get('members').getByNick(entry.match[0]).get("lastSpoke");
-                      // sort first by lastspoke in reverse order, then by nick
-                      return [-lastSpoke, entry.match[0].toLowerCase()].join("_");
-                    } else {
-                      return entry.match[0].toLowerCase();
+            // Sort first by last_spoke if appropriate, then by nick
+            autocomplete_list = _.sortByOrder(autocomplete_list,
+                [function (entry) {
+                    if (entry.type === 'nick' && _kiwi.global.settings.get('use_last_spoke_ordering')) {
+                            last_spoke = _kiwi.app.panels().active.get('members').getByNick(entry.match[0]).get("last_spoke");
+                            return last_spoke;
                     }
-                  } else {
-                    return entry.toLowerCase();
-                  }
-            });
+                    return -1;
+                },
+                function (entry) {
+                    return entry.type === 'nick' ? entry.match[0].toLowerCase() : entry.toLowerCase();
+                }],
+                ['desc','asc']
+            );
 
             this.showAutocomplete(autocomplete_list, 'nicks');
 

--- a/client/src/views/controlbox.js
+++ b/client/src/views/controlbox.js
@@ -208,7 +208,7 @@ _kiwi.view.ControlBox = Backbone.View.extend({
         var that = this,
             inp = $(ev.currentTarget),
             inp_val = inp.val(),
-            meta, last_spoke;
+            meta;
 
         if (navigator.appVersion.indexOf("Mac") !== -1) {
             meta = ev.metaKey;
@@ -332,9 +332,8 @@ _kiwi.view.ControlBox = Backbone.View.extend({
             // Sort first by last_spoke if appropriate, then by nick
             autocomplete_list = _.sortByOrder(autocomplete_list,
                 [function (entry) {
-                    if (entry.type === 'nick' && _kiwi.global.settings.get('use_last_spoke_ordering')) {
-                            last_spoke = _kiwi.app.panels().active.get('members').getByNick(entry.match[0]).get("last_spoke");
-                            return last_spoke;
+                    if (entry.type === 'nick' && _kiwi.global.settings.get('use_last_spoke_ordering') !== false ) {
+                            return _kiwi.app.panels().active.get('members').getByNick(entry.match[0]).get("last_spoke");
                     }
                     return -1;
                 },

--- a/config.example.js
+++ b/config.example.js
@@ -218,6 +218,7 @@ conf.client = {
         ignore_new_queries: false,
         count_all_activity: false,
         show_autocomplete_slideout: true,
+        use_last_spoke_ordering: false,
         locale: null // null = use the browser locale settings
     },
     window_title: 'Kiwi IRC'
@@ -242,7 +243,7 @@ conf.client_themes = [
 /*
  * If running multiple kiwi servers you may specify them here.
  * Note: All kiwi servers must have the same conf.http_base_path config option.
- * 
+ *
  * To force the client to connect to one other kiwi server, use:
  *     conf.client.kiwi_server = 'https://kiwi-server2.com';
  *

--- a/config.example.js
+++ b/config.example.js
@@ -218,7 +218,7 @@ conf.client = {
         ignore_new_queries: false,
         count_all_activity: false,
         show_autocomplete_slideout: true,
-        use_last_spoke_ordering: false,
+        use_last_spoke_ordering: true,
         locale: null // null = use the browser locale settings
     },
     window_title: 'Kiwi IRC'

--- a/kiwi
+++ b/kiwi
@@ -5,7 +5,7 @@ case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
-$(command -v nodejs || command -v node) $basedir/server/helpers/launcher.js "$@"
+"$(command -v nodejs || command -v node)" $basedir/server/helpers/launcher.js "$@"
 ret=$?
 
 exit $ret


### PR DESCRIPTION
Enclosing the call to node in the `kiwi` script prevents command failure for executable paths containing whitespace (e.g. `/c/Program Files/nodejs/node`).

Also adds last-spoke ordering for autocompletion, re: #575
