### PR TITLE
Fix text connect

### DIFF
--- a/client/src/translations/es.po
+++ b/client/src/translations/es.po
@@ -354,7 +354,7 @@ msgstr "Contraseña"
 
 #: 
 msgid "client_views_serverselect_connection_start"
-msgstr "Conectando..."
+msgstr "Conectar"
 
 #: 
 msgid "client_views_serverselect_server_and_network"


### PR DESCRIPTION
When you are in the login page the text always says "Conectando..." and should say "Conectar"