### PR TITLE
Add IrcConnection.capEnd() function to avoid sending CAP END twice

### DIFF
--- a/server/irc/commands/registration.js
+++ b/server/irc/commands/registration.js
@@ -74,8 +74,7 @@ var handlers = {
                     this.irc_connection.cap.requested = request;
                     this.irc_connection.write('CAP REQ :' + request.join(' '));
                 } else {
-                    this.irc_connection.write('CAP END');
-                    this.irc_connection.cap_negotiation = false;
+                    this.irc_connection.capEnd();
                 }
                 break;
             case 'ACK':
@@ -90,8 +89,7 @@ var handlers = {
                         this.irc_connection.sasl = true;
                         this.irc_connection.write('AUTHENTICATE PLAIN');
                     } else {
-                        this.irc_connection.write('CAP END');
-                        this.irc_connection.cap_negotiation = false;
+                        this.irc_connection.capEnd();
                     }
                 }
                 break;
@@ -100,8 +98,7 @@ var handlers = {
                     this.irc_connection.cap.requested = _.difference(this.irc_connection.cap.requested, capabilities);
                 }
                 if (this.irc_connection.cap.requested.length > 0) {
-                    this.irc_connection.write('CAP END');
-                    this.irc_connection.cap_negotiation = false;
+                    this.irc_connection.capEnd();
                 }
                 break;
             case 'LIST':
@@ -125,35 +122,28 @@ var handlers = {
                 this.irc_connection.write('AUTHENTICATE +');
             }
         } else {
-            this.irc_connection.write('CAP END');
-            this.irc_connection.cap_negotiation = false;
+            this.irc_connection.capEnd();
         }
     },
 
 
     RPL_SASLAUTHENTICATED: function (command) {
-        this.irc_connection.write('CAP END');
-        this.irc_connection.cap_negotiation = false;
+        this.irc_connection.capEnd();
         this.irc_connection.sasl = true;
     },
 
 
     RPL_SASLLOGGEDIN: function (command) {
-        if (this.irc_connection.cap_negotiation === true) {
-            this.irc_connection.write('CAP END');
-            this.irc_connection.cap_negotiation = false;
-        }
+        this.irc_connection.capEnd();
     },
 
     ERR_SASLNOTAUTHORISED: function (command) {
-        this.irc_connection.write('CAP END');
-        this.irc_connection.cap_negotiation = false;
+        this.irc_connection.capEnd();
     },
 
 
     ERR_SASLABORTED: function (command) {
-        this.irc_connection.write('CAP END');
-        this.irc_connection.cap_negotiation = false;
+        this.irc_connection.capEnd();
     },
 
 

--- a/server/irc/connection.js
+++ b/server/irc/connection.js
@@ -517,6 +517,16 @@ IrcConnection.prototype.capContainsAny = function (caps) {
 };
 
 
+/**
+ * Sends "CAP END" to end capability negotiation if it's still there
+ */
+IrcConnection.prototype.capEnd = function () {
+    if (this.cap_negotiation === true) {
+        this.write('CAP END');
+    }
+    this.cap_negotiation = false;
+};
+
 
 /**
  * Clean up this IrcConnection instance and any sockets


### PR DESCRIPTION
Other than the correctness issue, this is needed to prevent a crash in bitlbee 3.4.2 when CAP END is sent after registration, which kiwiirc seems to trigger when it receives 900 followed by a 903 later.

The crash itself is fixed in git versions of bitlbee, but it would be nice if kiwiirc worked fine with the last release.
