### PR TITLE
DNSBL patch 1

### DIFF
--- a/server_modules/dnsbl.js
+++ b/server_modules/dnsbl.js
@@ -1,62 +1,65 @@
 /**
- * DNS Blacklist support
+ * DNS Blacklist support. (Requires Node.js >= v4.x)
  *
- * Check the client against a blacklist before connection to an IRC server
+ *   You can set DNSBL zones in the config file under: conf.dnsbl.zones
+ *   Default: 'dnsbl.dronebl.org', 'rbl.efnetrbl.org', 'tor.dnsbl.sectoor.de'
+ *   Example:
+ *       conf.dnsbl = {
+ *           zones: ['dnsbl.dronebl.org', 'rbl.efnetrbl.org', 'tor.dnsbl.sectoor.de', 'socks.dnsbl.sorbs.net']
+ *       };
+ *
+ * Check the client against a blacklist before connection to an IRC server.
  */
-
 var dns = require('dns'),
-    kiwiModules = require('../server/modules');
+    util = require('util'),
+    kiwiModules = require('../server/modules'),
+    module = new kiwiModules.Module('DNSBL'),
+    config = require('../config');
 
-
-// The available DNS zones to check against
-var bl_zones = {
-    dronebl: '.dnsbl.dronebl.org'
-};
-
-// The DNS zone we should use
-var current_bl = 'dronebl';
-
-
-var module = new kiwiModules.Module('DNSBL');
-
+try {
+   var zones = config.production.dnsbl.zones;
+ } catch (e) {
+   var zones = null;
+}
 module.on('irc connecting', function (event, event_data) {
     event.wait = true;
-
-    var client_addr = event_data.connection.state.client.websocket.meta.real_address;
-
-    isBlacklisted(client_addr, function(is_blocked) {
-        if (is_blocked) {
-            var err = new Error('DNSBL blocked (' + client_addr + ')');
-            err.code = 'Blacklisted';
-
-            event_data.connection.emit('error', err);
-            event.preventDefault();
-            event.callback();
-
-        } else {
-            event.callback();
-        }
+    new DNSBL(zones).scan(event_data.connection.state.client.websocket.meta.real_address).then(function (res) {
+        var err = new Error(util.format('DNSBL blocked (%s) on (%s)', res.ip, res.zone));
+        err.code = 'Blacklisted';
+        event_data.connection.emit('error', err);
+        event.preventDefault();
+        event.callback();
+     }).catch(function (ip) {
+        event.callback();
     });
 });
 
-
-
-// The actual checking against the DNS blacklist
-function isBlacklisted(ip, callback) {
-    var host_lookup = reverseIp(ip) + bl_zones[current_bl];
-
-    dns.resolve4(host_lookup, function(err, domain) {
-        if (err) {
-            // Not blacklisted
-            callback(false);
-        } else {
-            // It is blacklisted
-            callback(true);
-        }
-    });
+/*
+ *  This is a basic DNSBL scanner. This is Promise based,
+ *  which means it requires Node.js v4.x or higher.
+ */
+function DNSBL (zones) {
+         this.zones = (Array.isArray(zones) ? zones : false) || [
+             'dnsbl.dronebl.org',
+             'rbl.efnetrbl.org',
+             'tor.dnsbl.sectoor.de'
+         ];
+         this.finished = 0;
+         return this;
 }
-
-
-function reverseIp(ip) {
-    return ip.split('.').reverse().join('.');
-}
+DNSBL.prototype.scan = function (ip) {
+         var rip = ip.split('.').reverse().join('.');
+         return new Promise((function (parent) {
+             return function (resolve, reject) {
+                 parent.zones.forEach(function (zone) {
+                     dns.resolve4(util.format('%s.%s', rip, zone), function (err, addrs) {
+                         if (Array.isArray(addrs) && !!addrs.length) {
+                            resolve({ ip: ip, reverse: rip, zone: zone.replace(/^\./,'') });
+                          } else if (++parent.finished >= parent.zones.length) {
+                            reject(ip);
+                         }
+                     });
+                 });
+             }
+         })(this));
+};


### PR DESCRIPTION
Add support for multiple DNSBL zones. The new defaults are 'dnsbl.dronebl.org', 'rbl.efnetrbl.org',  and 'tor.dnsbl.sectoor.de'. I've added in the option to modify zones via config.js as:

```js
conf.dnsbl = {
    zones: ['dnsbl.dronebl.org', 'rbl.efnetrbl.org', 'tor.dnsbl.sectoor.de', 'socks.dnsbl.sorbs.net']
};
```
I have chosen to use Promise, which is only supported with Node.js >=v4.x, however LTS for anything under v4.x expires at the end of 2016 so I believe this should be fine.