### PR TITLE
Updating node-static to version 0.7.10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ipaddr.js": "^1.0.3",
     "lodash": "^3.10.1",
     "negotiator": "^0.5.3",
-    "node-static": "^0.7.7",
+    "node-static": "^0.7.10",
     "po2json": "^0.4.1",
     "socksjs": "^0.5.0",
     "spdy": "^2.0.5",


### PR DESCRIPTION
This is required because previous version has a bug that makes KiwiIRC stop working.